### PR TITLE
Add support for collecting Self Boot Engine(SBE) dump

### DIFF
--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -65,7 +65,9 @@ std::map<uint8_t, DumpTypeInfo> dumpInfo = {
     {SBE::SBE_DUMP_TYPE_HOSTBOOT,
      {HB_DUMP_DBUS_OBJPATH, HB_DUMP_COLLECTION_PATH}},
     {SBE::SBE_DUMP_TYPE_HARDWARE,
-     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}}};
+     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}},
+    {SBE::SBE_DUMP_TYPE_SBE,
+     {SBE_DUMP_DBUS_OBJPATH, SBE_DUMP_COLLECTION_PATH}}};
 
 bool Manager::isMasterProc(struct pdbg_target* proc) const
 {
@@ -222,14 +224,19 @@ void Manager::collectDumpFromSBE(struct pdbg_target* proc,
             .c_str());
 }
 
+void Manager::collectSBEDump(std::filesystem::path& dumpPath, uint32_t id,
+                             const uint8_t chipPos)
+{
+    log<level::INFO>(
+        fmt::format("Collecting SBE dump: path({}), id({}), chip position({})",
+                    dumpPath.string(), id, chipPos)
+            .c_str());
+    std::exit(EXIT_FAILURE);
+}
+
 void Manager::collectDump(uint8_t type, uint32_t id, std::string errorLogId,
                           const uint64_t failingUnit)
 {
-    struct pdbg_target* target;
-    bool failed = false;
-    pdbg_targets_init(NULL);
-    pdbg_set_loglevel(PDBG_INFO);
-
     std::filesystem::path dumpPath(dumpInfo[type].dumpCollectionPath);
     dumpPath /= std::to_string(id);
     std::filesystem::path sbeFilePath = dumpPath / OP_SBE_FILES_PATH;
@@ -286,6 +293,22 @@ void Manager::collectDump(uint8_t type, uint32_t id, std::string errorLogId,
                           metadata::PATH(dumpPath.c_str()));
         }
     }
+
+    if (type == SBE::SBE_DUMP_TYPE_SBE)
+    {
+        collectSBEDump(sbeFilePath, id, failingUnit);
+        return;
+    }
+
+    struct pdbg_target* target;
+    bool failed = false;
+
+    if (!pdbg_targets_init(NULL))
+    {
+        log<level::ERR>("pdbg_targets_init failed");
+        throw std::runtime_error("pdbg target initialization failed");
+    }
+    pdbg_set_loglevel(PDBG_INFO);
 
     std::vector<uint8_t> clockStates = {SBE::SBE_CLOCK_ON, SBE::SBE_CLOCK_OFF};
     for (auto cstate : clockStates)
@@ -479,6 +502,10 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
     {
         type = SBE::SBE_DUMP_TYPE_HARDWARE;
     }
+    else if (dumpType == "com.ibm.Dump.Create.DumpType.SBE")
+    {
+        type = SBE::SBE_DUMP_TYPE_SBE;
+    }
     else
     {
         log<level::ERR>(fmt::format("Invalid dump type passed dumpType({})",
@@ -486,7 +513,8 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
                             .c_str());
     }
 
-    if (type == SBE::SBE_DUMP_TYPE_HARDWARE)
+    if ((type == SBE::SBE_DUMP_TYPE_HARDWARE) ||
+        (type == SBE::SBE_DUMP_TYPE_SBE))
     {
         iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
                                convertCreateParametersToString(

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -134,6 +134,14 @@ class Manager : public CreateIface
                             uint8_t type, uint8_t clockState,
                             const uint8_t chipPos,
                             const uint8_t collectFastArray);
+
+    /** @brief The function to collect SBE dump
+     *  @param[in] dumpPath - Path to store the dump
+     *  @param[in] id - Id of the dump
+     *  @param[in] chipPos - Position of the chip contains the SBE to be dumped.
+     */
+    void collectSBEDump(std::filesystem::path& dumpPath, uint32_t id,
+                        const uint8_t chipPos);
 };
 
 } // namespace dump

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -29,6 +29,10 @@ dump_conf_data.set_quoted('HW_DUMP_DBUS_OBJPATH', get_option('HW_DUMP_DBUS_OBJPA
                      description : 'The hardware dump manager path')
 dump_conf_data.set_quoted('HW_DUMP_COLLECTION_PATH', get_option('HW_DUMP_COLLECTION_PATH'),
                      description : 'The path to store collected hardware dump files')
+dump_conf_data.set_quoted('SBE_DUMP_DBUS_OBJPATH', get_option('SBE_DUMP_DBUS_OBJPATH'),
+                     description : 'The SBE dump manager path')
+dump_conf_data.set_quoted('SBE_DUMP_COLLECTION_PATH', get_option('SBE_DUMP_COLLECTION_PATH'),
+                     description : 'The path to store collected SBE dump files')
 configure_file(configuration : dump_conf_data,
                output : 'config.h')
 

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -8,6 +8,10 @@ namespace SBE
 // Dump type to the sbe_dump chipop
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
 constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
+
+// SBE dump type
+constexpr auto SBE_DUMP_TYPE_SBE = 0xA;
+
 // Clock state requested
 // Collect the dump with clocks on
 constexpr auto SBE_CLOCK_ON = 0x1;

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,15 @@ option('HW_DUMP_COLLECTION_PATH', type : 'string',
         value : '/tmp/openpower-dumps/hardware',
         description : 'The path to store collected hardware dump files')
 
+# SBE dump options
+option('SBE_DUMP_DBUS_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/sbe',
+        description : 'The SBE dump manager path')
+
+option('SBE_DUMP_COLLECTION_PATH', type : 'string',
+        value : '/tmp/openpower-dumps/sbe',
+        description : 'The path to store collected SBE dump files')
+
 # Feature to enable the dump collection
 option('dump-collection', type: 'feature',
        value : 'disabled',


### PR DESCRIPTION
Gerrit link: https://gerrit.openbmc-project.xyz/c/openbmc/openpower-debug-collector/+/47038 

Self Boot Engine(SBE) is a microcontroller that sits inside the processor
to initialize it to start the booting and also acts as a secure channel
for accessing certain control functions on the processor. During the
booting or other hardware access operations SBE can encounter errors
and become unresponsive. In such situations, the debug data needs to be
collected from such SBEs to find out the root cause of the error.
This data includes hardware state, configuration, memory, etc.
The collected data is then packaged into the OpenPOWER dump format
and which is called as SBE dump.

The SBE dump is collected from a dead SBE using special procedures
which execute hardware access instructions to get the memory
and other hardware states. This commit adds support for calling
such procedure implementations.

Test:
 busctl --verbose call org.open_power.Dump.Manager  /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/3";
};

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I020406b2d53d9d1f0a677a7defc4e55009c5e266

Conflicts:
	dump/dump_manager.cpp