### PR TITLE
Add support for collecting Self Boot Engine(SBE) dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,3 @@ Where
     if an invalid number is passed.
 - FAILING UNIT ID is an 8bit number indicating the id of the failing processor
   and the maximum allowed value is 32.
-
-

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ busctl --verbose call org.open_power.Dump.Manager
 
 ## Hardware dump collection interface
 
-The host dump collection interface can be invoked in the following way
+The hardware dump collection interface can be invoked in the following way
 
 ```
 busctl --verbose call org.open_power.Dump.Manager

--- a/README.md
+++ b/README.md
@@ -7,3 +7,40 @@ To build this package, do the following steps:
 
 To clean the repository run `rm -rf build`.
 ```
+
+## Hostboot dump collection interface
+
+The host dump collection interface can be invoked in the following way
+
+```
+busctl --verbose call org.open_power.Dump.Manager
+       /org/openpower/dump xyz.openbmc_project.Dump.Create
+       CreateDump a{sv} 2
+       "com.ibm.Dump.Create.CreateParameters.DumpType" s
+       "com.ibm.Dump.Create.DumpType.Hostboot"
+       "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t  <ERROR LOG ID>
+```
+
+## Hardware dump collection interface
+
+The host dump collection interface can be invoked in the following way
+
+```
+busctl --verbose call org.open_power.Dump.Manager
+       /org/openpower/dump xyz.openbmc_project.Dump.Create
+       CreateDump a{sv} 3
+       "com.ibm.Dump.Create.CreateParameters.DumpType" s
+       "com.ibm.Dump.Create.DumpType.Hardware"
+       "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t  <ERROR LOG ID>
+       "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t <FAILING_UNIT_ID>
+```
+
+Where
+- Valid dump types are listed [here](https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/com/ibm/Dump/Create.interface.yaml)
+- ERROR LOG ID is a 32bit number.
+  - An error will be logged and dump will be collected with error log id as 0,
+    if an invalid number is passed.
+- FAILING UNIT ID is an 8bit number indicating the id of the failing processor
+  and the maximum allowed value is 32.
+
+

--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -1,0 +1,366 @@
+extern "C"
+{
+#include <libpdbg_sbe.h>
+}
+
+#include "config.h"
+
+#include "attributes_info.H"
+
+#include "dump_collect.hpp"
+#include "dump_utils.hpp"
+#include "sbe_consts.hpp"
+
+#include <fmt/core.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+namespace openpower
+{
+namespace dump
+{
+using namespace phosphor::logging;
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+namespace sbe_chipop
+{
+
+void collectDumpFromSBE(struct pdbg_target* proc,
+                        const std::filesystem::path& path, const uint32_t id,
+                        const uint8_t type, const uint8_t clockState,
+                        const uint8_t chipPos, const uint8_t collectFastArray)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+    namespace fileError = sdbusplus::xyz::openbmc_project::Common::File::Error;
+
+    struct pdbg_target* pib = NULL;
+    pdbg_for_each_target("pib", proc, pib)
+    {
+        if (pdbg_target_probe(pib) != PDBG_TARGET_ENABLED)
+        {
+            continue;
+        }
+        break;
+    }
+
+    if (pib == NULL)
+    {
+        log<level::ERR>(fmt::format("No valid PIB target found dump type({}), "
+                                    "clockstate({}), proc position({}",
+                                    type, clockState, chipPos)
+                            .c_str());
+        throw std::runtime_error("No valid pib target found");
+    }
+
+    // TODO #ibm-openbmc/dev/3039
+    // Check the SBE state before attempt the dump collection
+    // Skip this SBE if the SBE is not in a good state.
+
+    int error = 0;
+    util::DumpDataPtr dataPtr;
+    uint32_t len = 0;
+
+    log<level::INFO>(
+        fmt::format(
+            "Collecting dump type({}), clockstate({}), proc position({})", type,
+            clockState, chipPos)
+            .c_str());
+    if ((error = sbe_dump(pib, type, clockState, collectFastArray,
+                          dataPtr.getPtr(), &len)) < 0)
+    {
+        // Add a trace if the failure is on the secondary.
+        if ((!util::isMasterProc(proc)) &&
+            (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+        {
+            log<level::ERR>(
+                fmt::format("Error in collecting dump from "
+                            "secondary SBE, chip_position({}) skipping",
+                            chipPos)
+                    .c_str());
+            return;
+        }
+        log<level::ERR>(
+            fmt::format("Failed to collect dump, chip_position({})", chipPos)
+                .c_str());
+        // TODO Create a PEL in the future for this failure case.
+        throw std::system_error(error, std::generic_category(),
+                                "Failed to collect dump from SBE");
+    }
+
+    if (len == 0)
+    {
+        // Add a trace if no data from secondary
+        if ((!util::isMasterProc(proc)) &&
+            (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+        {
+            log<level::INFO>(
+                fmt::format("No hostboot dump recieved from secondary SBE, "
+                            "skipping, chip_position({})",
+                            chipPos)
+                    .c_str());
+            return;
+        }
+        log<level::ERR>(
+            fmt::format(
+                "No data returned while collecting the dump chip_position({})",
+                chipPos)
+                .c_str());
+        throw std::runtime_error("No data returned while collecting the dump");
+    }
+
+    // Filename format: <dump_id>.SbeDataClocks<On/Off>.node0.proc<number>
+    std::stringstream ss;
+    ss << std::setw(8) << std::setfill('0') << id;
+
+    std::string clockStr = (clockState == SBE::SBE_CLOCK_ON) ? "On" : "Off";
+
+    // Assuming only node0 is supported now
+    std::string filename = ss.str() + ".SbeDataClocks" + clockStr +
+                           ".node0.proc" + std::to_string(chipPos);
+    std::filesystem::path dumpPath = path / filename;
+
+    std::ofstream outfile{dumpPath, std::ios::out | std::ios::binary};
+    if (!outfile.good())
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Open;
+        // Unable to open the file for writing
+        auto err = errno;
+        log<level::ERR>(
+            fmt::format(
+                "Error opening file to write dump, errno({}), filepath({})",
+                err, dumpPath.string())
+                .c_str());
+        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
+        // Just return here, so that the dumps collected from other
+        // SBEs can be packaged.
+        return;
+    }
+
+    outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
+                       std::ifstream::eofbit);
+
+    try
+    {
+        outfile.write(reinterpret_cast<char*>(dataPtr.getData()), len);
+        outfile.close();
+    }
+    catch (std::ofstream::failure& oe)
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Write;
+        log<level::ERR>(fmt::format("Failed to write to dump file, "
+                                    "errorMsg({}), error({}), filepath({})",
+                                    oe.what(), oe.code().value(),
+                                    dumpPath.string())
+                            .c_str());
+        report<Write>(metadata::ERRNO(oe.code().value()),
+                      metadata::PATH(dumpPath.c_str()));
+        // Just return here so dumps collected from other SBEs can be
+        // packaged.
+        return;
+    }
+    log<level::INFO>(
+        fmt::format("Dump collected type({}), clockstate({}), position({})",
+                    type, clockState, chipPos)
+            .c_str());
+}
+
+void collectDump(uint8_t type, uint32_t id, const uint64_t failingUnit,
+                 const std::filesystem::path& path)
+{
+    struct pdbg_target* target;
+    bool failed = false;
+
+    if (!pdbg_targets_init(NULL))
+    {
+        log<level::ERR>("pdbg_targets_init failed");
+        throw std::runtime_error("pdbg target initialization failed");
+    }
+    pdbg_set_loglevel(PDBG_INFO);
+
+    std::vector<uint8_t> clockStates = {SBE::SBE_CLOCK_ON, SBE::SBE_CLOCK_OFF};
+    for (auto cstate : clockStates)
+    {
+        std::vector<pid_t> pidList;
+        pdbg_for_each_class_target("proc", target)
+        {
+            if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED)
+            {
+                continue;
+            }
+
+            ATTR_HWAS_STATE_Type hwasState;
+            if (DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
+            {
+                log<level::ERR>("Attribute [ATTR_HWAS_STATE] get failed");
+                throw std::runtime_error(
+                    "Attribute [ATTR_HWAS_STATE] get failed");
+            }
+            // If the proc is not functional skip
+            if (!hwasState.functional)
+            {
+                if (util::isMasterProc(target))
+                {
+                    // Primary processor is not functional
+                    log<level::INFO>("Primary Processor is not functional");
+                }
+                continue;
+            }
+
+            uint32_t chipPos = 0;
+            if (DT_GET_PROP(ATTR_FAPI_POS, target, chipPos))
+            {
+                log<level::ERR>("Attribute [ATTR_FAPI_POS] get failed");
+                throw std::runtime_error(
+                    "Attribute [ATTR_FAPI_POS] get failed");
+                continue;
+            }
+
+            uint8_t collectFastArray = 0;
+            if (cstate == SBE::SBE_CLOCK_OFF)
+            {
+                if ((type == SBE::SBE_DUMP_TYPE_HOSTBOOT) ||
+                    ((type == SBE::SBE_DUMP_TYPE_HARDWARE) &&
+                     (chipPos == failingUnit)))
+                {
+                    collectFastArray = 1;
+                }
+            }
+
+            pid_t pid = fork();
+
+            if (pid < 0)
+            {
+                log<level::ERR>(
+                    "Fork failed while starting hostboot dump collection");
+
+                throw std::runtime_error(
+                    "Fork failed while starting hostboot dump collection");
+            }
+            else if (pid == 0)
+            {
+                try
+                {
+                    collectDumpFromSBE(target, path, id, type, cstate, chipPos,
+                                       collectFastArray);
+                }
+                catch (const std::runtime_error& error)
+                {
+                    log<level::ERR>(
+                        fmt::format(
+                            "Failed to execute collection, errorMsg({})",
+                            error.what())
+                            .c_str());
+                    std::exit(EXIT_FAILURE);
+                }
+                std::exit(EXIT_SUCCESS);
+            }
+            else
+            {
+                pidList.push_back(std::move(pid));
+            }
+        }
+
+        for (auto& p : pidList)
+        {
+            int status = 0;
+            waitpid(p, &status, 0);
+            if (WEXITSTATUS(status))
+            {
+                log<level::ERR>(
+                    fmt::format("Dump collection failed, status({}) pid({})",
+                                status, p)
+                        .c_str());
+                failed = true;
+            }
+        }
+
+        // Exit if there is a critical failure and collection cannot continue
+        if (failed)
+        {
+            log<level::ERR>("Failed to collect the dump");
+            std::exit(EXIT_FAILURE);
+        }
+        log<level::INFO>(
+            fmt::format("Dump collection completed for clock_state({})", cstate)
+                .c_str());
+    }
+}
+} // namespace sbe_chipop
+
+void prepareCollection(const std::filesystem::path& dumpPath,
+                       const std::string& errorLogId)
+{
+    try
+    {
+        std::filesystem::create_directories(dumpPath);
+    }
+    catch (std::filesystem::filesystem_error& e)
+    {
+        log<level::ERR>(fmt::format("Error creating dump directories, path({})",
+                                    dumpPath.string())
+                            .c_str());
+        report<InternalFailure>();
+        std::exit(EXIT_FAILURE);
+    }
+
+    std::filesystem::path elogPath = dumpPath.parent_path();
+    elogPath /= "ErrorLog";
+    std::ofstream outfile{elogPath, std::ios::out | std::ios::binary};
+    if (!outfile.good())
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Open;
+        // Unable to open the file for writing
+        auto err = errno;
+        log<level::ERR>(fmt::format("Error opening file to write errorlog id, "
+                                    "errno({}), filepath({})",
+                                    err, dumpPath.string())
+                            .c_str());
+        // Report the error and continue collection even if the error log id
+        // cannot be added
+        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
+    }
+    else
+    {
+        outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
+                           std::ifstream::eofbit);
+        try
+        {
+            outfile << errorLogId;
+            outfile.close();
+        }
+        catch (std::ofstream::failure& oe)
+        {
+            using namespace sdbusplus::xyz::openbmc_project::Common::File::
+                Error;
+            using metadata = xyz::openbmc_project::Common::File::Write;
+            // If there is an error commit the error and continue.
+            log<level::ERR>(fmt::format("Failed to write errorlog id to file, "
+                                        "errorMsg({}), error({}), filepath({})",
+                                        oe.what(), oe.code().value(),
+                                        dumpPath.string())
+                                .c_str());
+            // Report the error and continue with dump collection
+            // even if the error log id cannot be written to the file.
+            report<Write>(metadata::ERRNO(oe.code().value()),
+                          metadata::PATH(dumpPath.c_str()));
+        }
+    }
+}
+
+} // namespace dump
+} // namespace openpower

--- a/dump/dump_collect.hpp
+++ b/dump/dump_collect.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+extern "C"
+{
+#include <libpdbg.h>
+}
+
+#include <filesystem>
+
+namespace openpower
+{
+namespace dump
+{
+
+namespace sbe_chipop
+{
+/** @brief The function to orchestrate dump collection from different
+ *  SBEs
+ *  @param type - Type of the dump
+ *  @param id - A unique id assigned to dump to be collected
+ *  @param failingUnit - Chip position of the failing unit
+ *  @param sbeFilePath - Path where the collected dump to be stored
+ */
+void collectDump(const uint8_t type, const uint32_t id,
+                 const uint64_t failingUnit, const std::filesystem::path& path);
+
+/** @brief The function to collect dump from SBE
+ *  @param[in] proc - pdbg_target of the proc containing SBE to collect the
+ * dump.
+ *  @param[in] dumpPath - Path of directory to write the dump files.
+ *  @param[in] id - Id of the dump
+ *  @param[in] type - Type of the dump
+ *  @param[in] clockState - State of the clock while collecting.
+ *  @param[in] chipPos - Position of the chip
+ *  @param[in] collectFastArray - 0: skip fast array collection 1: collect
+ * fast array
+ */
+void collectDumpFromSBE(struct pdbg_target* proc,
+                        const std::filesystem::path& path, const uint32_t id,
+                        const uint8_t type, const uint8_t clockState,
+                        const uint8_t chipPos, const uint8_t collectFastArray);
+} // namespace sbe_chipop
+
+/** @brief create dump directories and add error log id
+ *  @param dumpPath Directory for collecting dump
+ *  @errorLogId Error log id associated with dump
+ */
+void prepareCollection(const std::filesystem::path& dumpPath,
+                       const std::string& errorLogId);
+
+} // namespace dump
+} // namespace openpower

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -5,13 +5,13 @@ extern "C"
 
 #include "config.h"
 
-#include "attributes_info.H"
-
+#include "dump_collect.hpp"
 #include "dump_manager.hpp"
 #include "dump_utils.hpp"
 #include "sbe_consts.hpp"
 
 #include <fmt/core.h>
+#include <libphal.H>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -65,348 +65,9 @@ std::map<uint8_t, DumpTypeInfo> dumpInfo = {
     {SBE::SBE_DUMP_TYPE_HOSTBOOT,
      {HB_DUMP_DBUS_OBJPATH, HB_DUMP_COLLECTION_PATH}},
     {SBE::SBE_DUMP_TYPE_HARDWARE,
-     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}}};
-
-bool Manager::isMasterProc(struct pdbg_target* proc) const
-{
-    ATTR_PROC_MASTER_TYPE_Type type;
-    // Get processor type (Primary or Alt-primary)
-    if (DT_GET_PROP(ATTR_PROC_MASTER_TYPE, proc, type))
-    {
-        log<level::ERR>("Attribute [ATTR_PROC_MASTER_TYPE] get failed");
-        throw std::runtime_error(
-            "Attribute [ATTR_PROC_MASTER_TYPE] get failed");
-    }
-
-    // Attribute value 0 corresponds to primary processor
-    if (type == ENUM_ATTR_PROC_MASTER_TYPE_ACTING_MASTER)
-    {
-        return true;
-    }
-    return false;
-}
-
-void Manager::collectDumpFromSBE(struct pdbg_target* proc,
-                                 std::filesystem::path& dumpPath,
-                                 const uint32_t id, const uint8_t type,
-                                 const uint8_t clockState,
-                                 const uint8_t chipPos,
-                                 const uint8_t collectFastArray)
-{
-    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
-    namespace fileError = sdbusplus::xyz::openbmc_project::Common::File::Error;
-
-    struct pdbg_target* pib = NULL;
-    pdbg_for_each_target("pib", proc, pib)
-    {
-        if (pdbg_target_probe(pib) != PDBG_TARGET_ENABLED)
-        {
-            continue;
-        }
-        break;
-    }
-
-    if (pib == NULL)
-    {
-        log<level::ERR>(fmt::format("No valid PIB target found dump type({}), "
-                                    "clockstate({}), proc position({}",
-                                    type, clockState, chipPos)
-                            .c_str());
-        throw std::runtime_error("No valid pib target found");
-    }
-
-    // TODO #ibm-openbmc/dev/3039
-    // Check the SBE state before attempt the dump collection
-    // Skip this SBE if the SBE is not in a good state.
-
-    int error = 0;
-    DumpDataPtr dataPtr;
-    uint32_t len = 0;
-
-    log<level::INFO>(
-        fmt::format(
-            "Collecting dump type({}), clockstate({}), proc position({})", type,
-            clockState, chipPos)
-            .c_str());
-    if ((error = sbe_dump(pib, type, clockState, collectFastArray,
-                          dataPtr.getPtr(), &len)) < 0)
-    {
-        // Add a trace if the failure is on the secondary.
-        if ((!isMasterProc(proc)) && (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
-        {
-            log<level::ERR>(
-                fmt::format("Error in collecting dump from "
-                            "secondary SBE, chip_position({}) skipping",
-                            chipPos)
-                    .c_str());
-            return;
-        }
-        log<level::ERR>(
-            fmt::format("Failed to collect dump, chip_position({})", chipPos)
-                .c_str());
-        // TODO Create a PEL in the future for this failure case.
-        throw std::system_error(error, std::generic_category(),
-                                "Failed to collect dump from SBE");
-    }
-
-    if (len == 0)
-    {
-        // Add a trace if no data from secondary
-        if ((!isMasterProc(proc)) && (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
-        {
-            log<level::INFO>(
-                fmt::format("No hostboot dump recieved from secondary SBE, "
-                            "skipping, chip_position({})",
-                            chipPos)
-                    .c_str());
-            return;
-        }
-        log<level::ERR>(
-            fmt::format(
-                "No data returned while collecting the dump chip_position({})",
-                chipPos)
-                .c_str());
-        throw std::runtime_error("No data returned while collecting the dump");
-    }
-
-    // Filename format: <dump_id>.SbeDataClocks<On/Off>.node0.proc<number>
-    std::stringstream ss;
-    ss << std::setw(8) << std::setfill('0') << id;
-
-    std::string clockStr = (clockState == SBE::SBE_CLOCK_ON) ? "On" : "Off";
-
-    // Assuming only node0 is supported now
-    std::string filename = ss.str() + ".SbeDataClocks" + clockStr +
-                           ".node0.proc" + std::to_string(chipPos);
-    dumpPath /= filename;
-
-    std::ofstream outfile{dumpPath, std::ios::out | std::ios::binary};
-    if (!outfile.good())
-    {
-        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
-        using metadata = xyz::openbmc_project::Common::File::Open;
-        // Unable to open the file for writing
-        auto err = errno;
-        log<level::ERR>(
-            fmt::format(
-                "Error opening file to write dump, errno({}), filepath({})",
-                err, dumpPath.string())
-                .c_str());
-        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
-        // Just return here, so that the dumps collected from other
-        // SBEs can be packaged.
-        return;
-    }
-
-    outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
-                       std::ifstream::eofbit);
-
-    try
-    {
-        outfile.write(reinterpret_cast<char*>(dataPtr.getData()), len);
-        outfile.close();
-    }
-    catch (std::ofstream::failure& oe)
-    {
-        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
-        using metadata = xyz::openbmc_project::Common::File::Write;
-        log<level::ERR>(fmt::format("Failed to write to dump file, "
-                                    "errorMsg({}), error({}), filepath({})",
-                                    oe.what(), oe.code().value(),
-                                    dumpPath.string())
-                            .c_str());
-        report<Write>(metadata::ERRNO(oe.code().value()),
-                      metadata::PATH(dumpPath.c_str()));
-        // Just return here so dumps collected from other SBEs can be
-        // packaged.
-        return;
-    }
-    log<level::INFO>(
-        fmt::format("Dump collected type({}), clockstate({}), position({})",
-                    type, clockState, chipPos)
-            .c_str());
-}
-
-void Manager::collectDump(uint8_t type, uint32_t id, std::string errorLogId,
-                          const uint64_t failingUnit)
-{
-    struct pdbg_target* target;
-    bool failed = false;
-
-    if (!pdbg_targets_init(NULL))
-    {
-        log<level::ERR>("pdbg_targets_init failed");
-        throw std::runtime_error("pdbg target initialization failed");
-    }
-    pdbg_set_loglevel(PDBG_INFO);
-
-    std::filesystem::path dumpPath(dumpInfo[type].dumpCollectionPath);
-    dumpPath /= std::to_string(id);
-    std::filesystem::path sbeFilePath = dumpPath / OP_SBE_FILES_PATH;
-    try
-    {
-        std::filesystem::create_directories(sbeFilePath);
-    }
-    catch (std::filesystem::filesystem_error& e)
-    {
-        log<level::ERR>(fmt::format("Error creating dump directories, path({})",
-                                    sbeFilePath.string())
-                            .c_str());
-        report<InternalFailure>();
-        std::exit(EXIT_FAILURE);
-    }
-
-    std::filesystem::path elogPath = dumpPath / "ErrorLog";
-    std::ofstream outfile{elogPath, std::ios::out | std::ios::binary};
-    if (!outfile.good())
-    {
-        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
-        using metadata = xyz::openbmc_project::Common::File::Open;
-        // Unable to open the file for writing
-        auto err = errno;
-        log<level::ERR>(fmt::format("Error opening file to write errorlog id, "
-                                    "errno({}), filepath({})",
-                                    err, dumpPath.string())
-                            .c_str());
-        // Report the error and continue collection even if the error log id
-        // cannot be added
-        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
-    }
-    else
-    {
-        outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
-                           std::ifstream::eofbit);
-        try
-        {
-            outfile << errorLogId;
-            outfile.close();
-        }
-        catch (std::ofstream::failure& oe)
-        {
-            using namespace sdbusplus::xyz::openbmc_project::Common::File::
-                Error;
-            using metadata = xyz::openbmc_project::Common::File::Write;
-            // If there is an error commit the error and continue.
-            log<level::ERR>(fmt::format("Failed to write errorlog id to file, "
-                                        "errorMsg({}), error({}), filepath({})",
-                                        oe.what(), oe.code().value(),
-                                        dumpPath.string())
-                                .c_str());
-            // Report the error and continue with dump collection
-            // even if the error log id cannot be written to the file.
-            report<Write>(metadata::ERRNO(oe.code().value()),
-                          metadata::PATH(dumpPath.c_str()));
-        }
-    }
-
-    std::vector<uint8_t> clockStates = {SBE::SBE_CLOCK_ON, SBE::SBE_CLOCK_OFF};
-    for (auto cstate : clockStates)
-    {
-        std::vector<pid_t> pidList;
-        pdbg_for_each_class_target("proc", target)
-        {
-            if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED)
-            {
-                continue;
-            }
-
-            ATTR_HWAS_STATE_Type hwasState;
-            if (DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
-            {
-                log<level::ERR>("Attribute [ATTR_HWAS_STATE] get failed");
-                throw std::runtime_error(
-                    "Attribute [ATTR_HWAS_STATE] get failed");
-            }
-            // If the proc is not functional skip
-            if (!hwasState.functional)
-            {
-                if (isMasterProc(target))
-                {
-                    // Primary processor is not functional
-                    log<level::INFO>("Primary Processor is not functional");
-                }
-                continue;
-            }
-
-            uint32_t chipPos = 0;
-            if (DT_GET_PROP(ATTR_FAPI_POS, target, chipPos))
-            {
-                log<level::ERR>("Attribute [ATTR_FAPI_POS] get failed");
-                throw std::runtime_error(
-                    "Attribute [ATTR_FAPI_POS] get failed");
-                continue;
-            }
-
-            uint8_t collectFastArray = 0;
-            if (cstate == SBE::SBE_CLOCK_OFF)
-            {
-                if ((type == SBE::SBE_DUMP_TYPE_HOSTBOOT) ||
-                    ((type == SBE::SBE_DUMP_TYPE_HARDWARE) &&
-                     (chipPos == failingUnit)))
-                {
-                    collectFastArray = 1;
-                }
-            }
-
-            pid_t pid = fork();
-
-            if (pid < 0)
-            {
-                log<level::ERR>(
-                    "Fork failed while starting hostboot dump collection");
-                report<InternalFailure>();
-                // Attempt the collection from next SBE.
-                continue;
-            }
-            else if (pid == 0)
-            {
-                try
-                {
-                    collectDumpFromSBE(target, sbeFilePath, id, type, cstate,
-                                       chipPos, collectFastArray);
-                }
-                catch (const std::runtime_error& error)
-                {
-                    log<level::ERR>(
-                        fmt::format(
-                            "Failed to execute collection, errorMsg({})",
-                            error.what())
-                            .c_str());
-                    std::exit(EXIT_FAILURE);
-                }
-                std::exit(EXIT_SUCCESS);
-            }
-            else
-            {
-                pidList.push_back(std::move(pid));
-            }
-        }
-
-        for (auto& p : pidList)
-        {
-            int status = 0;
-            waitpid(p, &status, 0);
-            if (WEXITSTATUS(status))
-            {
-                log<level::ERR>(
-                    fmt::format("Dump collection failed, status({}) pid({})",
-                                status, p)
-                        .c_str());
-                failed = true;
-            }
-        }
-
-        // Exit if there is a critical failure and collection cannot continue
-        if (failed)
-        {
-            log<level::ERR>("Failed to collect the dump");
-            std::exit(EXIT_FAILURE);
-        }
-        log<level::INFO>(
-            fmt::format("Dump collection completed for clock_state({})", cstate)
-                .c_str());
-    }
-}
+     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}},
+    {SBE::SBE_DUMP_TYPE_SBE,
+     {SBE_DUMP_DBUS_OBJPATH, SBE_DUMP_COLLECTION_PATH}}};
 
 sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
 {
@@ -487,56 +148,22 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
     {
         type = SBE::SBE_DUMP_TYPE_HARDWARE;
     }
+    else if (dumpType == "com.ibm.Dump.Create.DumpType.SBE")
+    {
+        type = SBE::SBE_DUMP_TYPE_SBE;
+    }
     else
     {
         log<level::ERR>(fmt::format("Invalid dump type passed dumpType({})",
                                     dumpType.c_str())
                             .c_str());
-    }
-
-    if (type == SBE::SBE_DUMP_TYPE_HARDWARE)
-    {
-        iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
-                               convertCreateParametersToString(
-                                   CreateParameters::FailingUnitId));
-        if (iter == params.end())
-        {
-            log<level::ERR>("Required argument, failing unit id is not passed");
-            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                                  Argument::ARGUMENT_VALUE("MISSING"));
-        }
-
-        try
-        {
-            failingUnit = std::get<uint64_t>(iter->second);
-        }
-        catch (const std::bad_variant_access& e)
-        {
-            // Exception will be raised if the input is not uint64
-            auto err = errno;
-            log<level::ERR>(
-                fmt::format("An invalid failing unit id is passed "
-                            "errorMsg({}), errno({}), errorString({})",
-                            e.what(), err, strerror(err))
-                    .c_str());
-            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
-        }
-
-        if (failingUnit > MAX_FAILING_UNIT)
-        {
-            log<level::ERR>(fmt::format("Invalid failing uint id: greater than "
-                                        "maximum number: input({})",
-                                        failingUnit)
-                                .c_str());
-            elog<InvalidArgument>(
-                Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                Argument::ARGUMENT_VALUE(std::to_string(failingUnit).c_str()));
-        }
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("DUMP_TYPE"),
+                              Argument::ARGUMENT_VALUE(dumpType.c_str()));
     }
 
     sdbusplus::message::object_path newDumpPath;
-    if (type == SBE::SBE_DUMP_TYPE_HARDWARE)
+    if ((type == SBE::SBE_DUMP_TYPE_HARDWARE) ||
+        (type == SBE::SBE_DUMP_TYPE_SBE))
     {
         iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
                                convertCreateParametersToString(
@@ -624,7 +251,32 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
     pid_t pid = fork();
     if (pid == 0)
     {
-        collectDump(type, id, elogId, failingUnit);
+        std::filesystem::path dumpPath(dumpInfo[type].dumpCollectionPath);
+        dumpPath /= std::to_string(id);
+        dumpPath /= OP_SBE_FILES_PATH;
+
+        prepareCollection(dumpPath, elogId);
+        if ((type == SBE::SBE_DUMP_TYPE_HARDWARE) ||
+            (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+        {
+            sbe_chipop::collectDump(type, id, failingUnit, dumpPath);
+        }
+        else if ((type == SBE::SBE_DUMP_TYPE_SBE))
+        {
+            try
+            {
+                openpower::phal::dump::collectSBEDump(id, failingUnit,
+                                                      dumpPath);
+            }
+            catch (const std::exception& e)
+            {
+                log<level::ERR>(
+                    fmt::format("Failed to collect SBE dump error({})",
+                                e.what())
+                        .c_str());
+                std::exit(EXIT_FAILURE);
+            }
+        }
         std::exit(EXIT_SUCCESS);
     }
     else if (pid < 0)

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -338,10 +338,14 @@ void Manager::collectDump(uint8_t type, uint32_t id, std::string errorLogId,
             }
 
             uint8_t collectFastArray = 0;
-            if ((cstate == SBE::SBE_CLOCK_OFF) &&
-                (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+            if (cstate == SBE::SBE_CLOCK_OFF)
             {
-                collectFastArray = 1;
+                if ((type == SBE::SBE_DUMP_TYPE_HOSTBOOT) ||
+                    ((type == SBE::SBE_DUMP_TYPE_HARDWARE) &&
+                     (chipPos == failingUnit)))
+                {
+                    collectFastArray = 1;
+                }
             }
 
             pid_t pid = fork();
@@ -532,6 +536,47 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
     }
 
     sdbusplus::message::object_path newDumpPath;
+    if (type == SBE::SBE_DUMP_TYPE_HARDWARE)
+    {
+        iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
+                               convertCreateParametersToString(
+                                   CreateParameters::FailingUnitId));
+        if (iter == params.end())
+        {
+            log<level::ERR>("Required argument, failing unit id is not passed");
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                                  Argument::ARGUMENT_VALUE("MISSING"));
+        }
+
+        try
+        {
+            failingUnit = std::get<uint64_t>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not uint64
+            auto err = errno;
+            log<level::ERR>(
+                fmt::format("An invalid failing unit id is passed "
+                            "errorMsg({}), errno({}), errorString({})",
+                            e.what(), err, strerror(err))
+                    .c_str());
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+
+        if (failingUnit > MAX_FAILING_UNIT)
+        {
+            log<level::ERR>(fmt::format("Invalid failing uint id: greater than "
+                                        "maximum number({}): input({})",
+                                        failingUnit, MAX_FAILING_UNIT)
+                                .c_str());
+            elog<InvalidArgument>(
+                Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                Argument::ARGUMENT_VALUE(std::to_string(failingUnit).c_str()));
+        }
+    }
+
     try
     {
         // Pass empty create parameters since no additional parameters
@@ -563,7 +608,7 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
         }
     }
 
-    // DUMP Path format /xyz/openbmc_project/dump/hostboot/entry/<id>
+    // DUMP Path format /xyz/openbmc_project/dump/<dump_type>/entry/<id>
     std::string pathStr = newDumpPath;
     auto pos = pathStr.rfind("/");
     if (pos == std::string::npos)

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -21,6 +21,7 @@ extern "C"
 #include <sdbusplus/exception.hpp>
 #include <xyz/openbmc_project/Common/File/error.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/Dump/Create/error.hpp>
 
 #include <chrono>
 #include <fstream>
@@ -44,6 +45,8 @@ constexpr auto STATUS_PROP = "Status";
 constexpr auto OP_SBE_FILES_PATH = "plat_dump";
 constexpr auto MAX_ERROR_LOG_ID = 0xFFFFFFFF;
 constexpr auto INVALID_FAILING_UNIT = 0xFF;
+constexpr auto ERROR_DUMP_DISABLED =
+    "xyz.openbmc_project.Dump.Create.Error.Disabled";
 
 // Maximum 32 processors are possible in a system.
 constexpr auto MAX_FAILING_UNIT = 0x20;
@@ -405,6 +408,8 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
     using CreateParameters =
         sdbusplus::com::ibm::Dump::server::Create::CreateParameters;
     using Argument = xyz::openbmc_project::Common::InvalidArgument;
+    using DumpDisabled =
+        sdbusplus::xyz::openbmc_project::Dump::Create::Error::Disabled;
 
     auto iter = params.find(
         sdbusplus::com::ibm::Dump::server::Create::
@@ -539,7 +544,15 @@ sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
         log<level::ERR>(
             fmt::format("D-Bus call exception, errorMsg({})", e.what())
                 .c_str());
-        elog<InternalFailure>();
+        if (e.name() == ERROR_DUMP_DISABLED)
+        {
+            elog<DumpDisabled>();
+        }
+        else
+        {
+            // re-throw exception
+            throw;
+        }
     }
 
     // DUMP Path format /xyz/openbmc_project/dump/<dump_type>/entry/<id>

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -1,0 +1,636 @@
+extern "C"
+{
+#include <libpdbg_sbe.h>
+}
+
+#include "config.h"
+
+#include "attributes_info.H"
+
+#include "dump_manager.hpp"
+#include "dump_utils.hpp"
+#include "sbe_consts.hpp"
+
+#include <fmt/core.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/exception.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <variant>
+#include <vector>
+
+namespace openpower
+{
+namespace dump
+{
+using namespace phosphor::logging;
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+constexpr auto DUMP_CREATE_IFACE = "xyz.openbmc_project.Dump.Create";
+constexpr auto DUMP_NOTIFY_IFACE = "xyz.openbmc_project.Dump.NewDump";
+constexpr auto DUMP_PROGRESS_IFACE = "xyz.openbmc_project.Common.Progress";
+constexpr auto STATUS_PROP = "Status";
+constexpr auto OP_SBE_FILES_PATH = "plat_dump";
+constexpr auto MAX_ERROR_LOG_ID = 0xFFFFFFFF;
+constexpr auto INVALID_FAILING_UNIT = 0xFF;
+
+// Maximum 32 processors are possible in a system.
+constexpr auto MAX_FAILING_UNIT = 0x20;
+
+/* @struct DumpTypeInfo
+ * @brief to store basic info about different dump types
+ */
+struct DumpTypeInfo
+{
+    std::string dumpPath;           // D-Bus path of the dump
+    std::string dumpCollectionPath; // Path were dumps are stored
+};
+
+/* Map of dump type to the basic info of the dumps */
+std::map<uint8_t, DumpTypeInfo> dumpInfo = {
+    {SBE::SBE_DUMP_TYPE_HOSTBOOT,
+     {HB_DUMP_DBUS_OBJPATH, HB_DUMP_COLLECTION_PATH}},
+    {SBE::SBE_DUMP_TYPE_HARDWARE,
+     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}}};
+
+bool Manager::isMasterProc(struct pdbg_target* proc) const
+{
+    ATTR_PROC_MASTER_TYPE_Type type;
+    // Get processor type (Primary or Alt-primary)
+    if (DT_GET_PROP(ATTR_PROC_MASTER_TYPE, proc, type))
+    {
+        log<level::ERR>("Attribute [ATTR_PROC_MASTER_TYPE] get failed");
+        throw std::runtime_error(
+            "Attribute [ATTR_PROC_MASTER_TYPE] get failed");
+    }
+
+    // Attribute value 0 corresponds to primary processor
+    if (type == 0)
+    {
+        return true;
+    }
+    return false;
+}
+
+void Manager::collectDumpFromSBE(struct pdbg_target* proc,
+                                 std::filesystem::path& dumpPath,
+                                 const uint32_t id, const uint8_t type,
+                                 const uint8_t clockState,
+                                 const uint8_t chipPos,
+                                 const uint8_t collectFastArray)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+    namespace fileError = sdbusplus::xyz::openbmc_project::Common::File::Error;
+
+    struct pdbg_target* pib = NULL;
+    pdbg_for_each_target("pib", proc, pib)
+    {
+        if (pdbg_target_probe(pib) != PDBG_TARGET_ENABLED)
+        {
+            continue;
+        }
+        break;
+    }
+
+    if (pib == NULL)
+    {
+        log<level::ERR>("No valid PIB target found");
+        throw std::runtime_error("No valid pib target found");
+    }
+
+    // TODO #ibm-openbmc/dev/3039
+    // Check the SBE state before attempt the dump collection
+    // Skip this SBE if the SBE is not in a good state.
+
+    int error = 0;
+    DumpDataPtr dataPtr;
+    uint32_t len = 0;
+
+    log<level::INFO>(
+        fmt::format("Collecting dump type({}), clockstate({}), position({})",
+                    type, clockState, chipPos)
+            .c_str());
+    if ((error = sbe_dump(pib, type, clockState, collectFastArray,
+                          dataPtr.getPtr(), &len)) < 0)
+    {
+        // Add a trace if the failure is on the secondary.
+        if ((!isMasterProc(proc)) && (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+        {
+            log<level::ERR>(fmt::format("Error in collecting dump from "
+                                        "secondary, chip_position({}) skipping",
+                                        chipPos)
+                                .c_str());
+            return;
+        }
+        log<level::ERR>(
+            fmt::format("Failed to collect dump, chip_position({})", chipPos)
+                .c_str());
+        // TODO Create a PEL in the future for this failure case.
+        throw std::system_error(error, std::generic_category(),
+                                "Failed to collect dump from SBE");
+    }
+
+    if (len == 0)
+    {
+        // Add a trace if no data from secondary
+        if ((!isMasterProc(proc)) && (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
+        {
+            log<level::INFO>(
+                fmt::format("No hostboot dump recieved from secondary SBE, "
+                            "skipping, chip_position({})",
+                            chipPos)
+                    .c_str());
+            return;
+        }
+        log<level::ERR>(
+            fmt::format(
+                "No data returned while collecting the dump chip_position({})",
+                chipPos)
+                .c_str());
+        throw std::runtime_error("No data returned while collecting the dump");
+    }
+
+    // Filename format: <dump_id>.SbeDataClocks<On/Off>.node0.proc<number>
+    std::stringstream ss;
+    ss << std::setw(8) << std::setfill('0') << id;
+    std::string idStr = ss.str();
+
+    std::string clockStr = (clockState == SBE::SBE_CLOCK_ON) ? "On" : "Off";
+
+    std::string filename = idStr + ".SbeDataClocks" + clockStr + ".node0.proc" +
+                           std::to_string(chipPos);
+    dumpPath /= filename;
+
+    std::ofstream outfile{dumpPath, std::ios::out | std::ios::binary};
+    if (!outfile.good())
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Open;
+        // Unable to open the file for writing
+        auto err = errno;
+        log<level::ERR>(
+            fmt::format(
+                "Error opening file to write dump, errno({}), filepath({})",
+                err, dumpPath.c_str())
+                .c_str());
+        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
+        // Just return here, so that the dumps collected from other
+        // SBEs can be packaged.
+        return;
+    }
+
+    outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
+                       std::ifstream::eofbit);
+
+    try
+    {
+        outfile.write(reinterpret_cast<char*>(dataPtr.getData()), len);
+        outfile.close();
+    }
+    catch (std::ofstream::failure& oe)
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Write;
+        log<level::ERR>(fmt::format("Failed to write to dump file, "
+                                    "errorMsg({}), error({}), filepath({})",
+                                    oe.what(), oe.code().value(),
+                                    dumpPath.c_str())
+                            .c_str());
+        report<Write>(metadata::ERRNO(oe.code().value()),
+                      metadata::PATH(dumpPath.c_str()));
+        // Just return here so dumps collected from other SBEs can be
+        // packaged.
+        return;
+    }
+    log<level::INFO>(
+        fmt::format("Dump collected type({}), clockstate({}), position({})",
+                    type, clockState, chipPos)
+            .c_str());
+}
+
+void Manager::collectDump(uint8_t type, uint32_t id, std::string errorLogId,
+                          const uint64_t failingUnit)
+{
+    struct pdbg_target* target;
+    bool failed = false;
+    pdbg_targets_init(NULL);
+    pdbg_set_loglevel(PDBG_INFO);
+
+    std::filesystem::path dumpPath(dumpInfo[type].dumpCollectionPath);
+    dumpPath /= std::to_string(id);
+    std::filesystem::path sbeFilePath = dumpPath / OP_SBE_FILES_PATH;
+    try
+    {
+        std::filesystem::create_directories(sbeFilePath);
+    }
+    catch (std::filesystem::filesystem_error& e)
+    {
+        log<level::ERR>(
+            fmt::format(
+                "Error creating dump directories, dump_type({}), path({})",
+                type, sbeFilePath.c_str())
+                .c_str());
+        report<InternalFailure>();
+        std::exit(EXIT_FAILURE);
+    }
+
+    std::filesystem::path elogPath = dumpPath / "ErrorLog";
+    std::ofstream outfile{elogPath, std::ios::out | std::ios::binary};
+    if (!outfile.good())
+    {
+        using namespace sdbusplus::xyz::openbmc_project::Common::File::Error;
+        using metadata = xyz::openbmc_project::Common::File::Open;
+        // Unable to open the file for writing
+        auto err = errno;
+        log<level::ERR>(fmt::format("Error opening file to write errorlog id, "
+                                    "errno({}), filepath({})",
+                                    err, dumpPath.c_str())
+                            .c_str());
+        report<Open>(metadata::ERRNO(err), metadata::PATH(dumpPath.c_str()));
+    }
+    else
+    {
+        outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
+                           std::ifstream::eofbit);
+        try
+        {
+            outfile << errorLogId;
+            outfile.close();
+        }
+        catch (std::ofstream::failure& oe)
+        {
+            using namespace sdbusplus::xyz::openbmc_project::Common::File::
+                Error;
+            using metadata = xyz::openbmc_project::Common::File::Write;
+            // If there is an error commit the error and continue.
+            log<level::ERR>(fmt::format("Failed to write errorlog id to file, "
+                                        "errorMsg({}), error({}), filepath({})",
+                                        oe.what(), oe.code().value(),
+                                        dumpPath.c_str())
+                                .c_str());
+            report<Write>(metadata::ERRNO(oe.code().value()),
+                          metadata::PATH(dumpPath.c_str()));
+        }
+    }
+
+    std::vector<uint8_t> clockStates = {SBE::SBE_CLOCK_ON, SBE::SBE_CLOCK_OFF};
+    for (auto cstate : clockStates)
+    {
+        std::vector<pid_t> pidList;
+        pdbg_for_each_class_target("proc", target)
+        {
+            if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED)
+            {
+                continue;
+            }
+
+            ATTR_HWAS_STATE_Type hwasState;
+            if (DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
+            {
+                log<level::ERR>("Attribute [ATTR_HWAS_STATE] get failed");
+                throw std::runtime_error(
+                    "Attribute [ATTR_HWAS_STATE] get failed");
+            }
+            // If the proc is not functional skip
+            if (!hwasState.functional)
+            {
+                if (isMasterProc(target))
+                {
+                    // Primary processor is not functional
+                    log<level::INFO>("Primary Processor is not functional");
+                }
+                continue;
+            }
+
+            uint32_t chipPos = 0;
+            if (DT_GET_PROP(ATTR_FAPI_POS, target, chipPos))
+            {
+                log<level::ERR>("Attribute [ATTR_FAPI_POS] get failed");
+                throw std::runtime_error(
+                    "Attribute [ATTR_FAPI_POS] get failed");
+                continue;
+            }
+
+            uint8_t collectFastArray = 0;
+            if (cstate == SBE::SBE_CLOCK_OFF)
+            {
+                if (type == SBE::SBE_DUMP_TYPE_HOSTBOOT)
+                {
+                    collectFastArray = 1;
+                }
+                if ((type == SBE::SBE_DUMP_TYPE_HARDWARE) &&
+                    (chipPos == failingUnit))
+                {
+                    collectFastArray = 1;
+                }
+            }
+
+            pid_t pid = fork();
+
+            if (pid < 0)
+            {
+                log<level::ERR>(
+                    "Fork failed while starting hostboot dump collection");
+                report<InternalFailure>();
+                // Attempt the collection from next SBE.
+                continue;
+            }
+            else if (pid == 0)
+            {
+                try
+                {
+                    collectDumpFromSBE(target, sbeFilePath, id, type, cstate,
+                                       chipPos, collectFastArray);
+                }
+                catch (const std::runtime_error& error)
+                {
+                    log<level::ERR>(
+                        fmt::format(
+                            "Failed to execute collection, errorMsg({})",
+                            error.what())
+                            .c_str());
+                    std::exit(EXIT_FAILURE);
+                }
+                std::exit(EXIT_SUCCESS);
+            }
+            else
+            {
+                pidList.push_back(std::move(pid));
+            }
+        }
+
+        for (auto& p : pidList)
+        {
+            int status = 0;
+            waitpid(p, &status, 0);
+            if (WEXITSTATUS(status))
+            {
+                log<level::ERR>(
+                    fmt::format("Dump collection failed, status({})", status)
+                        .c_str());
+                failed = true;
+            }
+        }
+
+        // Exit if there is a critical failure and collection cannot continue
+        if (failed)
+        {
+            log<level::ERR>("Failed to collect the dump");
+            std::exit(EXIT_FAILURE);
+        }
+        log<level::INFO>(
+            fmt::format("Dump collection completed for clock_state({})", cstate)
+                .c_str());
+    }
+}
+
+sdbusplus::message::object_path Manager::createDump(DumpCreateParams params)
+{
+    using namespace phosphor::logging;
+    DumpCreateParams createDumpParams;
+    sdbusplus::message::object_path newDumpPath;
+    using InvalidArgument =
+        sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+    using CreateParameters =
+        sdbusplus::com::ibm::Dump::server::Create::CreateParameters;
+    using Argument = xyz::openbmc_project::Common::InvalidArgument;
+
+    auto iter = params.find(
+        sdbusplus::com::ibm::Dump::server::Create::
+            convertCreateParametersToString(CreateParameters::DumpType));
+    if (iter == params.end())
+    {
+        log<level::ERR>("Required argument, dump type is not passed");
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("DUMP_TYPE"),
+                              Argument::ARGUMENT_VALUE("MISSING"));
+    }
+    std::string dumpType = std::get<std::string>(iter->second);
+
+    iter = params.find(
+        sdbusplus::com::ibm::Dump::server::Create::
+            convertCreateParametersToString(CreateParameters::ErrorLogId));
+    if (iter == params.end())
+    {
+        log<level::ERR>("Required argument, error log id is not passed");
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
+                              Argument::ARGUMENT_VALUE("MISSING"));
+    }
+
+    // get error log id
+    uint64_t errorId = 0;
+    try
+    {
+        errorId = std::get<uint64_t>(iter->second);
+    }
+    catch (const std::bad_variant_access& e)
+    {
+        // Exception will be raised if the input is not uint64
+        auto err = errno;
+        log<level::ERR>(fmt::format("An ivalid error log id is passed, setting "
+                                    "as 0, errorMsg({}), errno({}), error({})",
+                                    e.what(), err, strerror(err))
+                            .c_str());
+        report<InvalidArgument>(Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
+                                Argument::ARGUMENT_VALUE("INVALID INPUT"));
+    }
+
+    if (errorId > MAX_ERROR_LOG_ID)
+    {
+        // An error will be logged if the error log id is larger than maximum
+        // value and set the error log id as 0.
+        log<level::ERR>(fmt::format("Error log id is greater than maximum "
+                                    "length, setting as 0, errorid({})",
+                                    errorId)
+                            .c_str());
+        report<InvalidArgument>(
+            Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
+            Argument::ARGUMENT_VALUE(std::to_string(errorId).c_str()));
+    }
+
+    // Make it 8 char length string.
+    std::stringstream ss;
+    ss << std::setw(8) << std::setfill('0') << std::hex << errorId;
+    std::string elogId = ss.str();
+
+    uint8_t type = 0;
+    uint64_t failingUnit = INVALID_FAILING_UNIT;
+
+    if (dumpType == "com.ibm.Dump.Create.DumpType.Hostboot")
+    {
+        type = SBE::SBE_DUMP_TYPE_HOSTBOOT;
+    }
+    else if (dumpType == "com.ibm.Dump.Create.DumpType.Hardware")
+    {
+        type = SBE::SBE_DUMP_TYPE_HARDWARE;
+    }
+    else
+    {
+        log<level::ERR>(fmt::format("Invalid dump type passed dumpType({})",
+                                    dumpType.c_str())
+                            .c_str());
+    }
+
+    if (type == SBE::SBE_DUMP_TYPE_HARDWARE)
+    {
+        iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
+                               convertCreateParametersToString(
+                                   CreateParameters::FailingUnitId));
+        if (iter == params.end())
+        {
+            log<level::ERR>("Required argument, failing unit id is not passed");
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                                  Argument::ARGUMENT_VALUE("MISSING"));
+        }
+
+        try
+        {
+            failingUnit = std::get<uint64_t>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not uint64
+            auto err = errno;
+            log<level::ERR>(
+                fmt::format("An invalid failing unit id is passed "
+                            "errorMsg({}), errno({}), errorString({})",
+                            e.what(), err, strerror(err))
+                    .c_str());
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+
+        if (failingUnit > MAX_FAILING_UNIT)
+        {
+            log<level::ERR>(fmt::format("Invalid failing uint id: greater than "
+                                        "maximum number: input({})",
+                                        failingUnit)
+                                .c_str());
+            elog<InvalidArgument>(
+                Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
+                Argument::ARGUMENT_VALUE(std::to_string(failingUnit).c_str()));
+        }
+    }
+
+    try
+    {
+        auto dumpManager =
+            util::getService(bus, DUMP_CREATE_IFACE, dumpInfo[type].dumpPath);
+
+        auto method = bus.new_method_call(dumpManager.c_str(),
+                                          dumpInfo[type].dumpPath.c_str(),
+                                          DUMP_CREATE_IFACE, "CreateDump");
+        method.append(createDumpParams);
+        auto response = bus.call(method);
+        response.read(newDumpPath);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        log<level::ERR>(
+            fmt::format("D-Bus call exception, errorMsg({})", e.what())
+                .c_str());
+        elog<InternalFailure>();
+    }
+
+    // DUMP Path format /xyz/openbmc_project/dump/<dump_type>/entry/<id>
+    std::string pathStr = newDumpPath;
+    auto pos = pathStr.rfind("/");
+    if (pos == std::string::npos)
+    {
+        log<level::ERR>(
+            fmt::format("Invalid dump path, path({})", pathStr.c_str())
+                .c_str());
+        elog<InternalFailure>();
+    }
+
+    auto idString = pathStr.substr(pos + 1);
+    auto id = std::stoi(idString);
+
+    pid_t pid = fork();
+    if (pid == 0)
+    {
+        collectDump(type, id, elogId, failingUnit);
+        std::exit(EXIT_SUCCESS);
+    }
+    else if (pid < 0)
+    {
+        // Fork failed
+        log<level::ERR>("Failure in fork call");
+        elog<InternalFailure>();
+    }
+    else
+    {
+        using namespace sdeventplus::source;
+        Child::Callback callback =
+            [this, type, id, pathStr](Child& eventSource, const siginfo_t* si) {
+                eventSource.set_enabled(Enabled::On);
+                if (si->si_status == 0)
+                {
+                    log<level::INFO>("Dump collected, initiating packaging");
+                    auto dumpManager = util::getService(
+                        bus, DUMP_NOTIFY_IFACE, dumpInfo[type].dumpPath);
+                    auto method = bus.new_method_call(
+                        dumpManager.c_str(), dumpInfo[type].dumpPath.c_str(),
+                        DUMP_NOTIFY_IFACE, "Notify");
+                    method.append(static_cast<uint32_t>(id),
+                                  static_cast<uint64_t>(0));
+                    bus.call_noreply(method);
+                }
+                else
+                {
+                    log<level::ERR>("Dump collection failed, updating status");
+                    auto dumpManager =
+                        util::getService(bus, DUMP_PROGRESS_IFACE, pathStr);
+                    std::string failed = "xyz.openbmc_project.Common.Progress."
+                                         "OperationStatus.Failed";
+                    util::setProperty(DUMP_PROGRESS_IFACE, STATUS_PROP, pathStr,
+                                      dumpManager, bus, failed);
+                }
+            };
+        try
+        {
+            sigset_t ss;
+            if (sigemptyset(&ss) < 0)
+            {
+                log<level::ERR>("Unable to initialize signal set");
+                elog<InternalFailure>();
+            }
+            if (sigaddset(&ss, SIGCHLD) < 0)
+            {
+                log<level::ERR>("Unable to add signal to signal set");
+                elog<InternalFailure>();
+            }
+
+            // Block SIGCHLD first, so that the event loop can handle it
+            if (sigprocmask(SIG_BLOCK, &ss, NULL) < 0)
+            {
+                log<level::ERR>("Unable to block signal");
+                elog<InternalFailure>();
+            }
+            if (childPtr)
+            {
+                childPtr.reset();
+            }
+            childPtr = std::make_unique<Child>(event, pid, WEXITED | WSTOPPED,
+                                               std::move(callback));
+        }
+        catch (const InternalFailure& e)
+        {
+            commit<InternalFailure>();
+        }
+    }
+    // return object path
+    return newDumpPath;
+}
+} // namespace dump
+} // namespace openpower

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -115,8 +115,10 @@ class Manager : public CreateIface
      *  @param type - Type of the dump
      *  @param id - A unique id assigned to dump to be collected
      *  @param errorLogId - Id of the error log associated with this collection
+     *  @param failingUnit - Chip position of the failing unit
      */
-    void collectDump(uint8_t type, uint32_t id, std::string errorLogId);
+    void collectDump(uint8_t type, uint32_t id, std::string errorLogId,
+                     const uint64_t failingUnit);
 
     /** @brief The function to collect dump from SBE
      *  @param[in] proc - pdbg_target of the proc conating SBE to collect the

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -24,16 +24,17 @@ using CreateIface = sdbusplus::server::object::object<
 
 /** @struct DumpPtr
  * @brief a structure holding the data pointer
- * @details This is a RA11 containar for the dump data
+ * @details This is a RAII container for the dump data
  * returned by the SBE
  */
 struct DumpDataPtr
 {
   public:
-    /** @brief Distructor for the object, free the allocated memory.
+    /** @brief Destructor for the object, free the allocated memory.
      */
     ~DumpDataPtr()
     {
+        // The memory is allocated using malloc
         free(dataPtr);
     }
 
@@ -52,8 +53,7 @@ struct DumpDataPtr
     }
 
   private:
-    /** The pointer to the data
-     */
+    /** The pointer to the data */
     uint8_t* dataPtr = NULL;
 };
 
@@ -84,7 +84,8 @@ class Manager : public CreateIface
     {}
 
     /** @brief Implementation for createDump
-     *  Method to request a host dump when there is an error related to host.
+     *  Method to request a host dump when there is an error related to
+     *  host hardware or firmware.
      *  @param[in] params - Parameters for creating the dump.
      *
      *  @return object_path - The object path of the new dump entry.
@@ -110,17 +111,16 @@ class Manager : public CreateIface
     bool isMasterProc(struct pdbg_target* proc) const;
 
     /** @brief The function to orchestrate dump collection from different
-     *  sources
+     *  SBEs
      *  @param type - Type of the dump
      *  @param id - A unique id assigned to dump to be collected
      *  @param errorLogId - Id of the error log associated with this collection
-     *  @param failingUnit - Chip position of the failing unit
      */
-    void collectDump(uint8_t type, uint32_t id, std::string errorLogId,
-                     const uint64_t failingUnit);
+    void collectDump(uint8_t type, uint32_t id, std::string errorLogId);
 
     /** @brief The function to collect dump from SBE
-     *  @param[in] proc - pdbg_target of the SBE to collect the dump.
+     *  @param[in] proc - pdbg_target of the proc conating SBE to collect the
+     * dump.
      *  @param[in] dumpPath - Path of directory to write the dump files.
      *  @param[in] id - Id of the dump
      *  @param[in] type - Type of the dump

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <libpdbg.h>
-
 #include <com/ibm/Dump/Create/server.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -21,41 +19,6 @@ using DumpCreateParams =
 using CreateIface = sdbusplus::server::object::object<
     sdbusplus::com::ibm::Dump::server::Create,
     sdbusplus::xyz::openbmc_project::Dump::server::Create>;
-
-/** @struct DumpPtr
- * @brief a structure holding the data pointer
- * @details This is a RAII container for the dump data
- * returned by the SBE
- */
-struct DumpDataPtr
-{
-  public:
-    /** @brief Destructor for the object, free the allocated memory.
-     */
-    ~DumpDataPtr()
-    {
-        // The memory is allocated using malloc
-        free(dataPtr);
-    }
-
-    /** @brief Returns the pointer to the data
-     */
-    uint8_t** getPtr()
-    {
-        return &dataPtr;
-    }
-
-    /** @brief Returns the stored data
-     */
-    uint8_t* getData()
-    {
-        return dataPtr;
-    }
-
-  private:
-    /** The pointer to the data */
-    uint8_t* dataPtr = NULL;
-};
 
 /** @class Manager
  *  @brief Dump  manager class
@@ -102,40 +65,6 @@ class Manager : public CreateIface
 
     /** @brief SDEventPlus child pointer added to event loop */
     std::unique_ptr<sdeventplus::source::Child> childPtr = nullptr;
-
-    /** @brief Method to find whether a processor is master
-     *  @param[in] proc - pdbg_target for processor target
-     *
-     *  @return bool - true if master processor else false.
-     */
-    bool isMasterProc(struct pdbg_target* proc) const;
-
-    /** @brief The function to orchestrate dump collection from different
-     *  SBEs
-     *  @param type - Type of the dump
-     *  @param id - A unique id assigned to dump to be collected
-     *  @param errorLogId - Id of the error log associated with this collection
-     *  @param failingUnit - Chip position of the failing unit
-     */
-    void collectDump(uint8_t type, uint32_t id, std::string errorLogId,
-                     const uint64_t failingUnit);
-
-    /** @brief The function to collect dump from SBE
-     *  @param[in] proc - pdbg_target of the proc conating SBE to collect the
-     * dump.
-     *  @param[in] dumpPath - Path of directory to write the dump files.
-     *  @param[in] id - Id of the dump
-     *  @param[in] type - Type of the dump
-     *  @param[in] clockState - State of the clock while collecting.
-     *  @param[in] chipPos - Position of the chip
-     *  @param[in] collectFastArray - 0: skip fast array collection 1: collect
-     * fast array
-     */
-    void collectDumpFromSBE(struct pdbg_target* proc,
-                            std::filesystem::path& dumpPath, uint32_t id,
-                            uint8_t type, uint8_t clockState,
-                            const uint8_t chipPos,
-                            const uint8_t collectFastArray);
 };
 
 } // namespace dump

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -114,8 +114,10 @@ class Manager : public CreateIface
      *  @param type - Type of the dump
      *  @param id - A unique id assigned to dump to be collected
      *  @param errorLogId - Id of the error log associated with this collection
+     *  @param failingUnit - Chip position of the failing unit
      */
-    void collectDump(uint8_t type, uint32_t id, std::string errorLogId);
+    void collectDump(uint8_t type, uint32_t id, std::string errorLogId,
+                     const uint64_t failingUnit);
 
     /** @brief The function to collect dump from SBE
      *  @param[in] proc - pdbg_target of the SBE to collect the dump.

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -121,10 +121,15 @@ class Manager : public CreateIface
      *  @param[in] id - Id of the dump
      *  @param[in] type - Type of the dump
      *  @param[in] clockState - State of the clock while collecting.
+     *  @param[in] chipPos - Position of the chip
+     *  @param[in] collectFastArray - 0: skip fast array collection 1: collect
+     * fast array
      */
     void collectDumpFromSBE(struct pdbg_target* proc,
                             std::filesystem::path& dumpPath, uint32_t id,
-                            uint8_t type, uint8_t clockState);
+                            uint8_t type, uint8_t clockState,
+                            const uint8_t chipPos,
+                            const uint8_t collectFastArray);
 };
 
 } // namespace dump

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <libpdbg.h>
+
+#include <com/ibm/Dump/Create/server.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/child.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Dump/Create/server.hpp>
+
+#include <filesystem>
+
+namespace openpower
+{
+namespace dump
+{
+
+using CreateIface = sdbusplus::server::object::object<
+    sdbusplus::com::ibm::Dump::server::Create,
+    sdbusplus::xyz::openbmc_project::Dump::server::Create>;
+
+/** @struct DumpPtr
+ * @brief a structure holding the data pointer
+ * @details This is a RA11 containar for the dump data
+ * returned by the SBE
+ */
+struct DumpDataPtr
+{
+  public:
+    /** @brief Distructor for the object, free the allocated memory.
+     */
+    ~DumpDataPtr()
+    {
+        free(dataPtr);
+    }
+
+    /** @brief Returns the pointer to the data
+     */
+    uint8_t** getPtr()
+    {
+        return &dataPtr;
+    }
+
+    /** @brief Returns the stored data
+     */
+    uint8_t* getData()
+    {
+        return dataPtr;
+    }
+
+  private:
+    /** The pointer to the data
+     */
+    uint8_t* dataPtr = NULL;
+};
+
+/** @class Manager
+ *  @brief Dump  manager class
+ *  @details A concrete implementation for the
+ *  xyz::openbmc_project::Dump::server::Create D-Bus API.
+ */
+class Manager : public CreateIface
+{
+  public:
+    Manager() = delete;
+    Manager(const Manager&) = default;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+    virtual ~Manager() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path of the service.
+     *  @param[in] event - sd event handler.
+     */
+    Manager(sdbusplus::bus::bus& bus, const char* path,
+            sdeventplus::Event& event) :
+        CreateIface(bus, path, true),
+        bus(bus), event(event)
+    {}
+
+    /** @brief Implementation for createDump
+     *  Method to request a host dump when there is an error related to host.
+     *  @param[in] params - Parameters for creating the dump.
+     *
+     *  @return object_path - The object path of the new dump entry.
+     */
+    sdbusplus::message::object_path
+        createDump(std::map<std::string, std::string> params) override;
+
+  private:
+    /** @brief sdbusplus DBus bus connection. */
+    sdbusplus::bus::bus& bus;
+
+    /** @brief sdbusplus Dump event loop */
+    sdeventplus::Event& event;
+
+    /** @brief SDEventPlus child pointer added to event loop */
+    std::unique_ptr<sdeventplus::source::Child> childPtr = nullptr;
+
+    /** @brief Method to find whether a processor is master
+     *  @param[in] proc - pdbg_target for processor target
+     *
+     *  @return bool - true if master processor else false.
+     */
+    bool isMasterProc(struct pdbg_target* proc) const;
+
+    /** @brief The function to orchestrate dump collection from different
+     *  sources
+     *  @param type - Type of the dump
+     *  @param id - A unique id assigned to dump to be collected
+     *  @param errorLogId - Id of the error log associated with this collection
+     */
+    void collectDump(uint8_t type, uint32_t id, std::string errorLogId);
+
+    /** @brief The function to collect dump from SBE
+     *  @param[in] proc - pdbg_target of the SBE to collect the dump.
+     *  @param[in] dumpPath - Path of directory to write the dump files.
+     *  @param[in] id - Id of the dump
+     *  @param[in] type - Type of the dump
+     *  @param[in] clockState - State of the clock while collecting.
+     */
+    void collectDumpFromSBE(struct pdbg_target* proc,
+                            std::filesystem::path& dumpPath, uint32_t id,
+                            uint8_t type, uint8_t clockState);
+};
+
+} // namespace dump
+} // namespace openpower

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -16,6 +16,8 @@ namespace openpower
 namespace dump
 {
 
+using DumpCreateParams =
+    std::map<std::string, std::variant<std::string, uint64_t>>;
 using CreateIface = sdbusplus::server::object::object<
     sdbusplus::com::ibm::Dump::server::Create,
     sdbusplus::xyz::openbmc_project::Dump::server::Create>;
@@ -88,7 +90,7 @@ class Manager : public CreateIface
      *  @return object_path - The object path of the new dump entry.
      */
     sdbusplus::message::object_path
-        createDump(std::map<std::string, std::string> params) override;
+        createDump(DumpCreateParams params) override;
 
   private:
     /** @brief sdbusplus DBus bus connection. */

--- a/dump/dump_manager_main.cpp
+++ b/dump/dump_manager_main.cpp
@@ -15,6 +15,6 @@ int main()
     openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH, event);
 
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
-    event.loop();
-    return 0;
+    int rc = event.loop();
+    return rc;
 }

--- a/dump/dump_manager_main.cpp
+++ b/dump/dump_manager_main.cpp
@@ -1,0 +1,20 @@
+#include "config.h"
+
+#include "dump_manager.hpp"
+
+#include <sdbusplus/bus.hpp>
+int main()
+{
+    auto bus = sdbusplus::bus::new_default();
+    // Add sdbusplus ObjectManager for the 'root' path of the DUMP manager.
+    sdbusplus::server::manager::manager objManager(bus, OP_DUMP_OBJPATH);
+    bus.request_name(OP_DUMP_BUSNAME);
+
+    auto event = sdeventplus::Event::get_default();
+
+    openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH, event);
+
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    event.loop();
+    return 0;
+}

--- a/dump/dump_utils.cpp
+++ b/dump/dump_utils.cpp
@@ -50,6 +50,25 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& intf,
         throw std::runtime_error("Mapper call failed to get D-Bus name");
     }
 }
+
+bool isMasterProc(struct pdbg_target* proc)
+{
+    ATTR_PROC_MASTER_TYPE_Type type;
+    // Get processor type (Primary or Alt-primary)
+    if (DT_GET_PROP(ATTR_PROC_MASTER_TYPE, proc, type))
+    {
+        log<level::ERR>("Attribute [ATTR_PROC_MASTER_TYPE] get failed");
+        throw std::runtime_error(
+            "Attribute [ATTR_PROC_MASTER_TYPE] get failed");
+    }
+
+    // Attribute value 0 corresponds to primary processor
+    if (type == ENUM_ATTR_PROC_MASTER_TYPE_ACTING_MASTER)
+    {
+        return true;
+    }
+    return false;
+}
 } // namespace util
 } // namespace dump
 } // namespace openpower

--- a/dump/dump_utils.cpp
+++ b/dump/dump_utils.cpp
@@ -1,0 +1,52 @@
+#include "dump_utils.hpp"
+
+#include <phosphor-logging/log.hpp>
+
+#include <string>
+
+namespace openpower
+{
+namespace dump
+{
+namespace util
+{
+// Mapper
+constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
+constexpr auto MAPPER_PATH = "/xyz/openbmc_project/object_mapper";
+constexpr auto MAPPER_INTERFACE = "xyz.openbmc_project.ObjectMapper";
+
+using namespace phosphor::logging;
+
+std::string getService(sdbusplus::bus::bus& bus, const std::string& intf,
+                       const std::string& path)
+{
+    try
+    {
+        auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_PATH,
+                                          MAPPER_INTERFACE, "GetObject");
+
+        mapper.append(path, std::vector<std::string>({intf}));
+
+        auto mapperResponseMsg = bus.call(mapper);
+        std::map<std::string, std::vector<std::string>> mapperResponse;
+        mapperResponseMsg.read(mapperResponse);
+
+        if (mapperResponse.empty())
+        {
+            log<level::ERR>("ERROR in reading the mapper response");
+            throw std::runtime_error("ERROR in reading the mapper response");
+        }
+        return mapperResponse.begin()->first;
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        log<level::ERR>("Mapper call failed", entry("METHOD=%d", "GetObject"),
+                        entry("ERROR=%s", ex.what()),
+                        entry("PATH=%s", path.c_str()),
+                        entry("INTERFACE=%s", intf.c_str()));
+        throw std::runtime_error("Mapper call failed");
+    }
+}
+} // namespace util
+} // namespace dump
+} // namespace openpower

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -1,4 +1,10 @@
 #pragma once
+extern "C"
+{
+#include <libpdbg_sbe.h>
+}
+
+#include "attributes_info.H"
 
 #include <sdbusplus/server.hpp>
 
@@ -10,6 +16,41 @@ namespace dump
 {
 namespace util
 {
+
+/** @struct DumpPtr
+ * @brief a structure holding the data pointer
+ * @details This is a RAII container for the dump data
+ * returned by the SBE
+ */
+struct DumpDataPtr
+{
+  public:
+    /** @brief Destructor for the object, free the allocated memory.
+     */
+    ~DumpDataPtr()
+    {
+        // The memory is allocated using malloc
+        free(dataPtr);
+    }
+
+    /** @brief Returns the pointer to the data
+     */
+    uint8_t** getPtr()
+    {
+        return &dataPtr;
+    }
+
+    /** @brief Returns the stored data
+     */
+    uint8_t* getData()
+    {
+        return dataPtr;
+    }
+
+  private:
+    /** The pointer to the data */
+    uint8_t* dataPtr = NULL;
+};
 
 /**
  * @brief Get DBUS service for input interface via mapper call
@@ -45,6 +86,13 @@ void setProperty(const std::string& interface, const std::string& propertyName,
     method.append(interface, propertyName, value);
     auto reply = bus.call(method);
 }
+
+/** @brief Method to find whether a processor is master
+ *  @param[in] proc - pdbg_target for processor target
+ *
+ *  @return bool - true if master processor else false.
+ */
+bool isMasterProc(struct pdbg_target* proc);
 
 } // namespace util
 } // namespace dump

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -11,8 +11,6 @@ namespace dump
 namespace util
 {
 
-constexpr auto PROPERTY_INTF = "org.freedesktop.DBus.Properties";
-
 /**
  * @brief Get DBUS service for input interface via mapper call
  *
@@ -36,13 +34,15 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& intf,
  */
 template <typename T>
 void setProperty(const std::string& interface, const std::string& propertyName,
-                 const std::string& path, const std::string& service,
-                 sdbusplus::bus::bus& bus, T& value)
+                 const std::string& path, sdbusplus::bus::bus& bus,
+                 const T& value)
 {
-    std::variant<T> propertyValue(value);
+    constexpr auto PROPERTY_INTF = "org.freedesktop.DBus.Properties";
+
+    auto service = getService(bus, interface, path);
     auto method = bus.new_method_call(service.c_str(), path.c_str(),
                                       PROPERTY_INTF, "Set");
-    method.append(interface, propertyName, propertyValue);
+    method.append(interface, propertyName, value);
     auto reply = bus.call(method);
 }
 

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <sdbusplus/server.hpp>
+
+#include <string>
+
+namespace openpower
+{
+namespace dump
+{
+namespace util
+{
+
+constexpr auto PROPERTY_INTF = "org.freedesktop.DBus.Properties";
+
+/**
+ * @brief Get DBUS service for input interface via mapper call
+ *
+ * @param[in] bus -  DBUS Bus Object
+ * @param[in] intf - DBUS Interface
+ * @param[in] path - DBUS Object Path
+ *
+ * @return distinct dbus name for input interface/path
+ **/
+std::string getService(sdbusplus::bus::bus& bus, const std::string& intf,
+                       const std::string& path);
+
+/**
+ *
+ * @param[in] interface - the interface the property is on
+ * @param[in] propertName - the name of the property
+ * @param[in] path - the D-Bus path
+ * @param[in] service - the D-Bus service
+ * @param[in] bus - the D-Bus object
+ * @param[in] value - the value to set the property to
+ */
+template <typename T>
+void setProperty(const std::string& interface, const std::string& propertyName,
+                 const std::string& path, const std::string& service,
+                 sdbusplus::bus::bus& bus, T& value)
+{
+    std::variant<T> propertyValue(value);
+    auto method = bus.new_method_call(service.c_str(), path.c_str(),
+                                      PROPERTY_INTF, "Set");
+    method.append(interface, propertyName, propertyValue);
+    auto reply = bus.call(method);
+}
+
+} // namespace util
+} // namespace dump
+} // namespace openpower

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -13,6 +13,7 @@ dump_deps = [
     cxx.find_library('sdeventplus'),
     cxx.find_library('pdbg'),
     cxx.find_library('libdt-api'),
+    cxx.find_library('phal'),
 ]
 
 # Configuration header file(dump_config.h) generation
@@ -29,6 +30,10 @@ dump_conf_data.set_quoted('HW_DUMP_DBUS_OBJPATH', get_option('HW_DUMP_DBUS_OBJPA
                      description : 'The hardware dump manager path')
 dump_conf_data.set_quoted('HW_DUMP_COLLECTION_PATH', get_option('HW_DUMP_COLLECTION_PATH'),
                      description : 'The path to store collected hardware dump files')
+dump_conf_data.set_quoted('SBE_DUMP_DBUS_OBJPATH', get_option('SBE_DUMP_DBUS_OBJPATH'),
+                     description : 'The SBE dump manager path')
+dump_conf_data.set_quoted('SBE_DUMP_COLLECTION_PATH', get_option('SBE_DUMP_COLLECTION_PATH'),
+                     description : 'The path to store collected SBE dump files')
 configure_file(configuration : dump_conf_data,
                output : 'config.h')
 
@@ -36,6 +41,7 @@ configure_file(configuration : dump_conf_data,
 dump_src = files(
     'dump_manager.cpp',
     'dump_utils.cpp',
+    'dump_collect.cpp',
     'dump_manager_main.cpp',
 )
 

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+unit_files += {'input':'dump/org.open_power.Dump.Manager.service',
+         'output':'org.open_power.Dump.Manager.service'}
+
+cxx = meson.get_compiler('cpp')
+
+dump_deps = [
+    systemd,
+    sdbusplus,
+    phosphorlogging,
+    fmt_dep,
+    cxx.find_library('sdeventplus'),
+    cxx.find_library('pdbg'),
+    cxx.find_library('libdt-api'),
+]
+
+# Configuration header file(dump_config.h) generation
+dump_conf_data = configuration_data()
+dump_conf_data.set_quoted('OP_DUMP_OBJPATH', get_option('OP_DUMP_OBJPATH'),
+                     description : 'The D-Bus root of openpower-dump-collector')
+dump_conf_data.set_quoted('OP_DUMP_BUSNAME', get_option('OP_DUMP_BUSNAME'),
+                     description : 'The bus name of openpower-dump-collector')
+dump_conf_data.set_quoted('HB_DUMP_DBUS_OBJPATH', get_option('HB_DUMP_DBUS_OBJPATH'),
+                     description : 'The hostboot dump manager path')
+dump_conf_data.set_quoted('HB_DUMP_COLLECTION_PATH', get_option('HB_DUMP_COLLECTION_PATH'),
+                     description : 'The path to store collected hostboot dump files')
+dump_conf_data.set_quoted('HW_DUMP_DBUS_OBJPATH', get_option('HW_DUMP_DBUS_OBJPATH'),
+                     description : 'The hardware dump manager path')
+dump_conf_data.set_quoted('HW_DUMP_COLLECTION_PATH', get_option('HW_DUMP_COLLECTION_PATH'),
+                     description : 'The path to store collected hardware dump files')
+configure_file(configuration : dump_conf_data,
+               output : 'config.h')
+
+# source files
+dump_src = files(
+    'dump_manager.cpp',
+    'dump_utils.cpp',
+    'dump_manager_main.cpp',
+)
+
+executable('openpower-dump-manager',
+    dump_src,
+    dependencies: dump_deps,
+    implicit_include_directories: true,
+    install: true
+)

--- a/dump/org.open_power.Dump.Manager.service
+++ b/dump/org.open_power.Dump.Manager.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=OpenPOWER Dump Manager
+After=obmc-host-start-pre@0.target
+After=start_host@0.service
+Wants=xyz.openbmc_project.Dump.Manager.service
+After=xyz.openbmc_project.Dump.Manager.service
+Before=mapper-wait@-org-open_power-dump-manager.service
+Conflicts=obmc-host-stop@0.target
+
+[Service]
+Environment="PDBG_DTB=/var/lib/phosphor-software-manager/pnor/rw/DEVTREE"
+ExecStart=/usr/bin/openpower-dump-manager
+Restart=always
+Type=dbus
+BusName={BUSNAME}
+
+[Install]
+WantedBy=obmc-host-startmin@0.target

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -8,6 +8,7 @@ namespace SBE
 // Dump type to the sbe_dump chipop
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
 constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
+
 // Clock state requested
 // Collect the dump with clocks on
 constexpr auto SBE_CLOCK_ON = 0x1;

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -8,7 +8,6 @@ namespace SBE
 // Dump type to the sbe_dump chipop
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
 constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
-
 // Clock state requested
 // Collect the dump with clocks on
 constexpr auto SBE_CLOCK_ON = 0x1;

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -8,6 +8,10 @@ namespace SBE
 // Dump type to the sbe_dump chipop
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
 constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
+
+// SBE dump type
+constexpr auto SBE_DUMP_TYPE_SBE = 0xA;
+
 // Clock state requested
 // Collect the dump with clocks on
 constexpr auto SBE_CLOCK_ON = 0x1;

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -7,7 +7,7 @@ namespace SBE
 {
 // Dump type to the sbe_dump chipop
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
-
+constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
 // Clock state requested
 // Collect the dump with clocks on
 constexpr auto SBE_CLOCK_ON = 0x1;

--- a/dump/sbe_consts.hpp
+++ b/dump/sbe_consts.hpp
@@ -1,0 +1,22 @@
+#pragma once
+namespace openpower
+{
+namespace dump
+{
+namespace SBE
+{
+// Dump type to the sbe_dump chipop
+constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
+
+// Clock state requested
+// Collect the dump with clocks on
+constexpr auto SBE_CLOCK_ON = 0x1;
+
+// Collect the dumps with clock off
+constexpr auto SBE_CLOCK_OFF = 0x2;
+
+// SBE MSG Register to know whether SBE is booted
+constexpr auto SBE_MSG_REGISTER = 0x2809;
+} // namespace SBE
+} // namespace dump
+} // namespace openpower

--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,6 @@ else
     watchdog_lib = []
 endif
 
-
 # list of unit files, the path as input and service name
 # as output
 # eg: unit_file += {'input:'<path>, 'output':<service name>}

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,16 @@ else
     watchdog_lib = []
 endif
 
+
+# list of unit files, the path as input and service name
+# as output
+# eg: unit_file += {'input:'<path>, 'output':<service name>}
+unit_files = []
+
+if get_option('dump-collection').enabled()
+    subdir('dump')
+endif
+
 executable('watchdog_timeout',
     'watchdog_timeout.cpp',
     configure_file(output: 'config.h', configuration: conf_data),
@@ -114,3 +124,17 @@ executable('checkstop_app',
     implicit_include_directories: true,
     install: true
 )
+
+unit_subs = configuration_data()
+unit_subs.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+systemd_system_unit_dir = dependency('systemd').get_variable(
+    pkgconfig: 'systemdsystemunitdir')
+foreach u : unit_files
+    configure_file(
+        configuration: unit_subs,
+        input: u.get('input'),
+        install: true,
+        install_dir: systemd_system_unit_dir,
+        output: u.get('output')
+    )
+endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,7 +15,7 @@ option('OP_DUMP_BUSNAME', type : 'string',
         value : 'org.open_power.Dump.Manager',
         description : 'The bus name of openpower-dump-collector')
 
-# hostboot dump values
+# Hostboot dump options
 option('HB_DUMP_DBUS_OBJPATH', type : 'string',
         value : '/xyz/openbmc_project/dump/hostboot',
         description : 'The hostboot dump manager path')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,7 +15,7 @@ option('OP_DUMP_BUSNAME', type : 'string',
         value : 'org.open_power.Dump.Manager',
         description : 'The bus name of openpower-dump-collector')
 
-# Hostboot dump options
+# hostboot dump values
 option('HB_DUMP_DBUS_OBJPATH', type : 'string',
         value : '/xyz/openbmc_project/dump/hostboot',
         description : 'The hostboot dump manager path')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,15 @@ option('HW_DUMP_COLLECTION_PATH', type : 'string',
         value : '/tmp/openpower-dumps/hardware',
         description : 'The path to store collected hardware dump files')
 
+# SBE dump options
+option('SBE_DUMP_DBUS_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/sbe',
+        description : 'The SBE dump manager path')
+
+option('SBE_DUMP_COLLECTION_PATH', type : 'string',
+        value : '/tmp/openpower-dumps/sbe',
+        description : 'The path to store collected SBE dump files')
+
 # Feature to enable the dump collection
 option('dump-collection', type: 'feature',
        value : 'disabled',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # Feature to enable hostboot dump collection when watchdog times out
 option('hostboot-dump-collection',
        type: 'feature',
        value: 'disabled',
        description : 'Enables hostboot dump collection')
+
+# The options and values for dump collection
+option('OP_DUMP_OBJPATH', type : 'string',
+        value : '/org/openpower/dump',
+        description : 'The D-Bus root of openpower-dump-collector')
+
+option('OP_DUMP_BUSNAME', type : 'string',
+        value : 'org.open_power.Dump.Manager',
+        description : 'The bus name of openpower-dump-collector')
+
+# Hostboot dump options
+option('HB_DUMP_DBUS_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/hostboot',
+        description : 'The hostboot dump manager path')
+
+option('HB_DUMP_COLLECTION_PATH', type : 'string',
+        value : '/tmp/openpower-dumps/hostboot',
+        description : 'The path to store collected hostboot dump files')
+
+# Hardware dump options
+option('HW_DUMP_DBUS_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/hardware',
+        description : 'The hardware dump manager path')
+
+option('HW_DUMP_COLLECTION_PATH', type : 'string',
+        value : '/tmp/openpower-dumps/hardware',
+        description : 'The path to store collected hardware dump files')
+
+# Feature to enable the dump collection
+option('dump-collection', type: 'feature',
+       value : 'disabled',
+       description : 'Enables dump collection')

--- a/sbe_consts.hpp
+++ b/sbe_consts.hpp
@@ -1,0 +1,22 @@
+#pragma once
+namespace openpower
+{
+namespace dump
+{
+namespace SBE
+{
+// Dump type to the sbe_dump chipop
+constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
+
+// Clock state requested
+// Collect the dump with clocks on
+constexpr auto SBE_CLOCK_ON = 0x1;
+
+// Collect the dumps with clock off
+constexpr auto SBE_CLOCK_OFF = 0x2;
+
+// SBE MSG Register to know whether SBE is booted
+constexpr auto SBE_MSG_REGISTER = 0x2809;
+} // namespace SBE
+} // namespace dump
+} // namespace openpower


### PR DESCRIPTION
Review link: https://gerrit.openbmc-project.xyz/c/openbmc/openpower-debug-collector/+/47038

SBE is a microcontroller that sits inside the processor
to initialize it to start the booting and also acts as a secure channel
for accessing certain control functions on the processor. During the
booting or other hardware access operations SBE can encounter errors
and become unresponsive. In such situations, the debug data needs to be
collected from such SBEs to find out the root cause of the error.
This data includes hardware state, configuration, memory, etc.
The collected data is then packaged into the OpenPOWER dump format
and which is called as SBE dump.

The SBE dump is collected from an responsive SBE using special procedures
which execute hardware access instructions to get the memory
and other hardware states. This commit add support for calling
such procedure implementations.

Test:
 busctl --verbose call org.open_power.Dump.Manager  /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/3";
};