### PR TITLE
Request hostboot dump when Host State is 'Running'

### DIFF
--- a/watchdog/watchdog_dbus.hpp
+++ b/watchdog/watchdog_dbus.hpp
@@ -51,5 +51,12 @@ uint32_t createPel(const std::string& eventType,
                    std::map<std::string, std::string>& additional,
                    const std::vector<FFDCTuple>& ffdc);
 
+/**
+ * @brief Query host state
+ *
+ * @return true if the CurrentHostState is 'Running'
+ */
+bool isHostStateRunning();
+
 } // namespace dump
 } // namespace watchdog

--- a/watchdog_timeout.cpp
+++ b/watchdog_timeout.cpp
@@ -55,6 +55,15 @@ int main(int argc, char* argv[])
         bool primaryIplDone = sbe::isPrimaryIplDone();
         if (primaryIplDone)
         {
+            // Collect hostboot dump only if the host is in 'Running' state
+            if (!isHostStateRunning())
+            {
+                log<level::INFO>(
+                    "CurrentHostState is not in 'Running' state. Dump maybe "
+                    "already occurring, skipping this dump request...");
+                return EXIT_SUCCESS;
+            }
+
             // SBE boot done, Need to collect hostboot dump
             log<level::INFO>("Handle Hostboot boot failure");
             triggerHostbootDump(timeout);


### PR DESCRIPTION
When CurrentHostStatus is not in 'Running' state, either host is 'Off'
or current state is changed by HW dump to a state other than 'Running'
and may have initiated/created the dump. In these cases, there is
no need to initiate hostboot dump. This commit allows initiating
hostboot dump collection when the current host state is 'Running'
and the watchdog times out.

Testing:
Run watchdog_timeout and check the following entries in the journal log:
'Running' state:
Mar 03 12:22:34 rain127bmc watchdog_timeout[3626]: Host did not respond
within watchdog timeout interval
Mar 03 12:22:34 rain127bmc watchdog_timeout[3626]: Handle Hostboot boot
failure
Mar 03 12:22:34 rain127bmc watchdog_timeout[3626]: hostboot dump
requested
Mar 03 12:23:26 rain127bmc watchdog_timeout[3626]:
/xyz/openbmc_project/dump/hostboot/entry/20000028
Mar 03 12:23:26 rain127bmc watchdog_timeout[3626]:
xyz.openbmc_project.Common.Progress.OperationStatus.Completed
Mar 03 12:23:26 rain127bmc watchdog_timeout[3626]: dump collection
completed

'Quiesced' state:
Mar 03 12:26:04 rain127bmc watchdog_timeout[3917]: Host did not respond
within watchdog timeout interval
Mar 03 12:26:04 rain127bmc watchdog_timeout[3917]: Host is not in
'Running' state. Dump maybe already occurring, skipping this dump
request...

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>
Change-Id: I7245fef1639299bf501667eef48e275a93307c00