### PR TITLE
openpower-dump-manager needs to be up when chassis on

### DIFF
--- a/dump/org.open_power.Dump.Manager.service
+++ b/dump/org.open_power.Dump.Manager.service
@@ -5,7 +5,7 @@ Before=start_host@0.service
 Wants=xyz.openbmc_project.Dump.Manager.service
 After=xyz.openbmc_project.Dump.Manager.service
 Before=mapper-wait@-org-open_power-dump-manager.service
-Conflicts=obmc-host-stop@0.target
+Conflicts=obmc-chassis-poweroff@0.target
 
 [Service]
 Environment="PDBG_DTB=/var/lib/phosphor-software-manager/pnor/rw/DEVTREE"


### PR DESCRIPTION
Add service org.open_power.Dump.Manager to control the
openpower-dump-manager application for collecting the
openpower dumps on BMC.
Patch to link service file:
https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/42327

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I7adf5848eec674d7997ba24e56a5a1265cd8c3eb
