### PR TITLE
Fix crash while requesting multiple SBE dumps

### DIFF
--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -73,6 +73,68 @@ std::map<uint8_t, DumpTypeInfo> dumpInfo = {
     {SBE::SBE_DUMP_TYPE_SBE,
      {SBE_DUMP_DBUS_OBJPATH, SBE_DUMP_COLLECTION_PATH}}};
 
+/* @struct DumpData
+ * @brief To store the data for notifying the status of dump
+ */
+struct DumpData
+{
+    uint32_t id;
+    uint8_t type;
+    std::string pathStr;
+    DumpData(uint32_t id, uint8_t type, std::string pathStr) :
+        id(id), type(type), pathStr(pathStr)
+    {}
+};
+
+static int callback(sd_event_source*, const siginfo_t* si, void* data)
+{
+    using namespace phosphor::logging;
+    using InternalFailure =
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+    DumpData* dumpData = reinterpret_cast<DumpData*>(data);
+    log<level::INFO>(
+        fmt::format("Updating status of path({})", dumpData->pathStr).c_str());
+    auto bus = sdbusplus::bus::new_system();
+    try
+    {
+        if (si->si_status == 0)
+        {
+            log<level::INFO>("Dump collected, initiating packaging");
+            auto dumpManager = util::getService(
+                bus, DUMP_NOTIFY_IFACE, dumpInfo[dumpData->type].dumpPath);
+            auto method = bus.new_method_call(
+                dumpManager.c_str(), dumpInfo[dumpData->type].dumpPath.c_str(),
+                DUMP_NOTIFY_IFACE, "Notify");
+            method.append(static_cast<uint32_t>(dumpData->id),
+                          static_cast<uint64_t>(0));
+            bus.call_noreply(method);
+        }
+        else
+        {
+            log<level::ERR>("Dump collection failed, updating status");
+            util::setProperty(
+                DUMP_PROGRESS_IFACE, STATUS_PROP, dumpData->pathStr, bus,
+                std::variant<std::string>("xyz.openbmc_project.Common.Progress."
+                                          "OperationStatus.Failed"));
+        }
+    }
+    catch (const InternalFailure& e)
+    {
+        commit<InternalFailure>();
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        log<level::ERR>(
+            fmt::format(
+                "Unable to update the dump status, errorMsg({}) path({})",
+                e.what(), dumpData->pathStr)
+                .c_str());
+        commit<InternalFailure>();
+    }
+    delete dumpData;
+    return 0;
+}
+
 sdbusplus::message::object_path
     Manager::createDump(util::DumpCreateParams params)
 {
@@ -314,70 +376,26 @@ sdbusplus::message::object_path
     }
     else
     {
-        using namespace sdeventplus::source;
-        Child::Callback callback =
-            [this, type, id, pathStr](Child& eventSource, const siginfo_t* si) {
-                eventSource.set_enabled(Enabled::On);
-                if (si->si_status == 0)
-                {
-                    log<level::INFO>("Dump collected, initiating packaging");
-                    auto dumpManager = util::getService(
-                        bus, DUMP_NOTIFY_IFACE, dumpInfo[type].dumpPath);
-                    auto method = bus.new_method_call(
-                        dumpManager.c_str(), dumpInfo[type].dumpPath.c_str(),
-                        DUMP_NOTIFY_IFACE, "Notify");
-                    method.append(static_cast<uint32_t>(id),
-                                  static_cast<uint64_t>(0));
-                    bus.call_noreply(method);
-                }
-                else
-                {
-                    log<level::ERR>("Dump collection failed, updating status");
-                    util::setProperty(DUMP_PROGRESS_IFACE, STATUS_PROP, pathStr,
-                                      bus,
-                                      std::variant<std::string>(
-                                          "xyz.openbmc_project.Common.Progress."
-                                          "OperationStatus.Failed"));
-                }
-            };
-        try
+        using InternalFailure =
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+        log<level::ERR>(
+            fmt::format(
+                "Adding handler for id({}), type({}), path({}), pid({})", id,
+                type, pathStr, pid)
+                .c_str());
+        DumpData* data = new DumpData(id, type, pathStr);
+        auto rc =
+            sd_event_add_child(eventLoop.get(), nullptr, pid,
+                               WEXITED | WSTOPPED, callback, (void*)(data));
+        if (0 > rc)
         {
-            sigset_t ss;
-            if (sigemptyset(&ss) < 0)
-            {
-                log<level::ERR>("Unable to initialize signal set");
-                elog<InternalFailure>();
-            }
-            if (sigaddset(&ss, SIGCHLD) < 0)
-            {
-                log<level::ERR>("Unable to add signal to signal set");
-                elog<InternalFailure>();
-            }
-
-            // Block SIGCHLD first, so that the event loop can handle it
-            if (sigprocmask(SIG_BLOCK, &ss, NULL) < 0)
-            {
-                log<level::ERR>("Unable to block signal");
-                elog<InternalFailure>();
-            }
-            if (childPtr)
-            {
-                childPtr.reset();
-            }
-            childPtr = std::make_unique<Child>(event, pid, WEXITED | WSTOPPED,
-                                               std::move(callback));
-        }
-        catch (const InternalFailure& e)
-        {
-            commit<InternalFailure>();
-        }
-        catch (const sdbusplus::exception::exception& e)
-        {
+            // Failed to add to event loop
             log<level::ERR>(
-                fmt::format("Unable to update the dump status, errorMsg({})",
-                            e.what())
+                fmt::format(
+                    "Error occurred during the sd_event_add_child call, rc({})",
+                    rc)
                     .c_str());
-            commit<InternalFailure>();
+            elog<InternalFailure>();
         }
     }
     // return object path

--- a/dump/dump_manager_main.cpp
+++ b/dump/dump_manager_main.cpp
@@ -1,20 +1,67 @@
 #include "config.h"
 
 #include "dump_manager.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
 
+#include <fmt/core.h>
+
+#include <phosphor-logging/elog-errors.hpp>
 #include <sdbusplus/bus.hpp>
+
 int main()
 {
+    using namespace phosphor::logging;
+    using InternalFailure =
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
     auto bus = sdbusplus::bus::new_default();
+    sd_event* event = nullptr;
+    auto rc = sd_event_default(&event);
+    if (rc < 0)
+    {
+        log<level::ERR>(
+            fmt::format("Error occurred during the sd_event_default, rc({})",
+                        rc)
+                .c_str());
+        report<InternalFailure>();
+        return rc;
+    }
+    openpower::dump::EventPtr eventP{event};
+    event = nullptr;
+
+    // Blocking SIGCHLD is needed for calling sd_event_add_child
+    sigset_t mask;
+    if (sigemptyset(&mask) < 0)
+    {
+        log<level::ERR>(
+            fmt::format("Unable to initialize signal set, errno({})", errno)
+                .c_str());
+        return EXIT_FAILURE;
+    }
+
+    if (sigaddset(&mask, SIGCHLD) < 0)
+    {
+        log<level::ERR>(
+            fmt::format("Unable to add signal to signal set, errno({})", errno)
+                .c_str());
+        return EXIT_FAILURE;
+    }
+
+    // Block SIGCHLD first, so that the event loop can handle it
+    if (sigprocmask(SIG_BLOCK, &mask, nullptr) < 0)
+    {
+        log<level::ERR>(
+            fmt::format("Unable to block signal, errno({})", errno).c_str());
+        return EXIT_FAILURE;
+    }
+
     // Add sdbusplus ObjectManager for the 'root' path of the DUMP manager.
     sdbusplus::server::manager::manager objManager(bus, OP_DUMP_OBJPATH);
     bus.request_name(OP_DUMP_BUSNAME);
 
-    auto event = sdeventplus::Event::get_default();
+    openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH, eventP);
 
-    openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH, event);
-
-    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
-    int rc = event.loop();
+    bus.attach_event(eventP.get(), SD_EVENT_PRIORITY_NORMAL);
+    rc = sd_event_loop(eventP.get());
     return rc;
 }


### PR DESCRIPTION
The event mechanism was supporting only one dump at a time
because the second dump was requested was overwriting the
first one. Changed event mechanism as in phosphor-debug-
collector

Tested
Created 4 SBE dumps together and offloaded


Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I4ecee76041a3161094d0161ebdbb711ef15a2090