### PR TITLE
Request a BMC dump at the end of system dump collection

### DIFF
--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -329,6 +329,12 @@ sdbusplus::message::object_path
     auto idString = pathStr.substr(pos + 1);
     auto id = std::stoi(idString);
 
+    // Initiating a BMC dump
+    log<level::INFO>(
+        fmt::format("Initiating a BMC dump for host dump({})", pathStr)
+            .c_str());
+    openpower::dump::util::requestBMCDump();
+
     pid_t pid = fork();
     if (pid == 0)
     {

--- a/dump/dump_utils.cpp
+++ b/dump/dump_utils.cpp
@@ -104,6 +104,38 @@ void monitorDump(const std::string& path, const uint32_t timeout)
     }
 }
 
+void requestBMCDump()
+{
+    constexpr auto path = "/xyz/openbmc_project/dump/bmc";
+    constexpr auto interface = "xyz.openbmc_project.Dump.Create";
+    constexpr auto function = "CreateDump";
+
+    log<level::INFO>("Initiating BMC dump");
+    auto bus = sdbusplus::bus::new_default();
+    try
+    {
+        std::string service = getService(bus, interface, path);
+        auto method =
+            bus.new_method_call(service.c_str(), path, interface, function);
+        std::map<std::string, std::variant<std::string, uint64_t>> createParams;
+        method.append(createParams);
+
+        auto response = bus.call(method);
+
+        sdbusplus::message::object_path reply;
+        response.read(reply);
+        log<level::INFO>(
+            fmt::format("BMC dump initiated path({})", std::string(reply))
+                .c_str());
+    }
+    catch (const std::exception& e)
+    {
+        log<level::ERR>(
+            fmt::format("BMC dump creation reqest failed, error({})", e.what())
+                .c_str());
+    }
+}
+
 void requestSBEDump(const uint32_t failingUnit, const uint32_t eid)
 {
     log<level::INFO>(fmt::format("Requesting Dump PEL({}) chip position({})",

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -113,6 +113,11 @@ void requestSBEDump(const uint32_t failingUnit, const uint32_t eid);
  */
 void prepareCollection(const std::filesystem::path& dumpPath,
                        const std::string& errorLogId);
+/**
+ * Request BMC dump from dump manager
+ *
+ */
+void requestBMCDump();
 
 } // namespace util
 } // namespace dump


### PR DESCRIPTION
An additional BMC dump will help debugging the host error
because the journal and the error log on the BMC can help
debugging the host errors. Add a new method to request
BMC dump at the end of the collection

Tests:
  Intitiate SBE, Hostboot and Hardware dumps and make sure
  BMC dumps are created and not impacted the collection
  host dumps

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: Id29d3044306f23842242b62697c7cdc397481ec7