### PR TITLE
sdevent - cater for releasing linux inode for openpower dumps

### DIFF
--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -10,6 +10,7 @@
 #include <xyz/openbmc_project/Dump/Create/server.hpp>
 
 #include <filesystem>
+#include <map>
 
 namespace openpower
 {
@@ -29,7 +30,7 @@ using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
 using CreateIface = sdbusplus::server::object::object<
     sdbusplus::com::ibm::Dump::server::Create,
     sdbusplus::xyz::openbmc_project::Dump::server::Create>;
-
+using ::sdeventplus::source::Child;
 /** @class Manager
  *  @brief Dump  manager class
  *  @details A concrete implementation for the
@@ -70,6 +71,9 @@ class Manager : public CreateIface
 
     /** @brief sdbusplus Dump event loop */
     EventPtr eventLoop;
+
+    /** @brief map of SDEventPlus child pointer added to event loop */
+    std::map<pid_t, std::unique_ptr<Child>> childPtrMap;
 };
 
 } // namespace dump


### PR DESCRIPTION
For every dump generated an "anon_inode:[pidfd]" entry is created for the
associated process and the same is not released. When the number of inode
entries reach the maximum count dump request will fail and the dump service
takes a reset with a core dump.

When a dump is requested a child process is spawned to perform dump collection.
Parent process waits on the child process completion using sd-event-add-child
systemd call. sd-event-add-child adds an inode entry which needs to be released
during the callback method called after child process exit using unref but the
same is not done.

Now switching to sdeventplus::source::Child wrapper class for sd-event-add-child
which takes care of releasing the inode fd.

Tested:
tested hardware, sbe , resource dump generation successfully

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I43745a5218b8fe20bcd3ace384fe9d9d4cf197b1