### PR TITLE
sdbusplus: object: don't use 'bool' argument constructor

### DIFF
--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -51,7 +51,7 @@ class Manager : public CreateIface
      *  @param[in] event - sd event handler.
      */
     Manager(sdbusplus::bus::bus& bus, const char* path, const EventPtr& event) :
-        CreateIface(bus, path, true), bus(bus), eventLoop(event.get())
+        CreateIface(bus, path), bus(bus), eventLoop(event.get())
     {}
 
     /** @brief Implementation for createDump


### PR DESCRIPTION
Looks like the "true" was just a copy/paste from elsewhere. Remove it
(since no longer supported) and utilize the default which is to emit an
object added signal on constructor call.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>