### PR TITLE
dump : fix service file and install as part of repository build

### DIFF
--- a/dump/dist/meson.build
+++ b/dump/dist/meson.build
@@ -1,0 +1,36 @@
+systemd_system_unit_dir = systemd_dep.get_variable(
+    pkgconfig:'systemdsystemunitdir')
+conf_data = configuration_data()
+conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
+
+configure_file(
+  input: 'org.open_power.Dump.Manager@.service.in',
+  output: 'org.open_power.Dump.Manager@.service',
+  configuration: conf_data,
+  install: true,
+  install_dir: systemd_system_unit_dir)
+
+systemd_alias = [[
+    '../org.open_power.Dump.Manager@.service',
+    'obmc-host-startmin@0.target.wants/org.open_power.Dump.Manager@0.service'
+]]
+
+foreach service: systemd_alias
+    # Meson 0.61 will support this:
+    #install_symlink(
+    #      service,
+    #      install_dir: systemd_system_unit_dir,
+    #      pointing_to: link,
+    #  )
+    meson.add_install_script(
+        'sh', '-c',
+        'mkdir -p $(dirname $DESTDIR/@0@/@1@)'.format(systemd_system_unit_dir,
+            service[1]),
+    )   
+    meson.add_install_script(
+        'sh', '-c',
+        'ln -s @0@ $DESTDIR/@1@/@2@'.format(service[0], systemd_system_unit_dir,
+            service[1]),
+    )   
+endforeach
+

--- a/dump/dist/org.open_power.Dump.Manager@.service.in
+++ b/dump/dist/org.open_power.Dump.Manager@.service.in
@@ -1,18 +1,18 @@
 [Unit]
-Description=OpenPOWER Dump Manager
-After=obmc-host-start-pre@0.target
-Before=start_host@0.service
+Description=OpenPOWER Dump Manager Host %i
+After=obmc-host-start-pre@i.target
+Before=start_host@i.service
 Wants=xyz.openbmc_project.Dump.Manager.service
 After=xyz.openbmc_project.Dump.Manager.service
-Before=mapper-wait@-org-open_power-dump-manager.service
-Conflicts=obmc-chassis-poweroff@0.target
+Before=mapper-wait@-org-open_power-dump-manager@i.service
+Conflicts=obmc-chassis-poweroff@i.target
 
 [Service]
 Environment="PDBG_DTB=/var/lib/phosphor-software-manager/pnor/rw/DEVTREE"
 ExecStart=/usr/bin/openpower-dump-manager
 Restart=always
 Type=dbus
-BusName={BUSNAME}
+BusName=org.open_power.Dump.Manager
 
 [Install]
 WantedBy=obmc-host-startmin@0.target

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-
-unit_files += {'input':'dump/org.open_power.Dump.Manager.service',
-         'output':'org.open_power.Dump.Manager.service'}
-
 cxx = meson.get_compiler('cpp')
 
 sdeventplus_dep = dependency('sdeventplus')
 
+systemd_dep = dependency('systemd')
+
 dump_deps = [
-    systemd,
+    systemd_dep,
     sdbusplus_dep,
     phosphor_dbus_interfaces_dep,
     sdeventplus_dep,
@@ -74,3 +72,5 @@ executable('dump-collect',
     implicit_include_directories: true,
     install: true
 )
+
+subdir('dist')


### PR DESCRIPTION
Made changes to install the org.open_power.Dump.Manager@.service as part of the repository build and also create soft links.

1) Now modified to install the service file and create softlink as part of repository build
2) Modified the service file with templated approach as the service starts before start host@i target.

Upstream commit link
https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/42328

Tested
root@p10bmc:~# obmcutil state
CurrentBMCState     : xyz.openbmc_project.State.BMC.BMCState.Ready
CurrentPowerState   : xyz.openbmc_project.State.Chassis.PowerState.On
CurrentHostState    : xyz.openbmc_project.State.Host.HostState.Off
BootProgress        : xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified
OperatingSystemState: xyz.openbmc_project.State.OperatingSystem.Status.OSStatus.Inactive

root@p10bmc:~# systemctl status org.open_power.Dump.Manager@0.service
* org.open_power.Dump.Manager@0.service - OpenPOWER Dump Manager Host 0
     Loaded: loaded (/lib/systemd/system/org.open_power.Dump.Manager@.service; static)
     Active: inactive (dead)

root@p10bmc:~#obmcutil poweron

root@p10bmc:~# systemctl status org.open_power.Dump.Manager@0.service
* org.open_power.Dump.Manager@0.service - OpenPOWER Dump Manager Host 0
     Loaded: loaded (/lib/systemd/system/org.open_power.Dump.Manager@.service; static)
     Active: active (running) since Wed 2023-02-22 08:17:26 UTC; 1min 29s ago
   Main PID: 917 (openpower-dump-)
     CGroup: /system.slice/system-org.open_power.Dump.Manager.slice/org.open_power.Dump.Manager@0.service
             `-917 /usr/bin/openpower-dump-manager

Feb 22 08:17:25 p10bmc systemd[1]: Starting OpenPOWER Dump Manager Host 0...
Feb 22 08:17:26 p10bmc systemd[1]: Started OpenPOWER Dump Manager Host 0.


root@p10bmc:~# busctl tree org.open_power.Dump.Manager
`-/org
  `-/org/openpower
    `-/org/openpower/dump

Change-Id: Ice236af70cec8433835d24d3ae4bdaf55c7e82cf