### PR TITLE
dump: change dump service to non template version

### DIFF
--- a/dump/dist/meson.build
+++ b/dump/dist/meson.build
@@ -4,15 +4,15 @@ conf_data = configuration_data()
 conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
 
 configure_file(
-  input: 'org.open_power.Dump.Manager@.service.in',
-  output: 'org.open_power.Dump.Manager@.service',
+  input: 'org.open_power.Dump.Manager.service.in',
+  output: 'org.open_power.Dump.Manager.service',
   configuration: conf_data,
   install: true,
   install_dir: systemd_system_unit_dir)
 
 systemd_alias = [[
-    '../org.open_power.Dump.Manager@.service',
-    'obmc-host-startmin@0.target.wants/org.open_power.Dump.Manager@0.service'
+    '../org.open_power.Dump.Manager.service',
+    'obmc-host-startmin@0.target.wants/org.open_power.Dump.Manager.service'
 ]]
 
 foreach service: systemd_alias

--- a/dump/dist/org.open_power.Dump.Manager.service.in
+++ b/dump/dist/org.open_power.Dump.Manager.service.in
@@ -1,11 +1,11 @@
 [Unit]
-Description=OpenPOWER Dump Manager Host %i
-After=obmc-host-start-pre@i.target
-Before=start_host@i.service
+Description=OpenPOWER Dump Manager Host 
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
 Wants=xyz.openbmc_project.Dump.Manager.service
 After=xyz.openbmc_project.Dump.Manager.service
-Before=mapper-wait@-org-open_power-dump-manager@i.service
-Conflicts=obmc-chassis-poweroff@i.target
+Before=mapper-wait@-org-open_power-dump-manager@0.service
+Conflicts=obmc-chassis-poweroff@0.target
 
 [Service]
 Environment="PDBG_DTB=/var/lib/phosphor-software-manager/pnor/rw/DEVTREE"


### PR DESCRIPTION
upstream commit link
https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/42328

Tested:
root@p10bmc:~# systemctl status org.open_power.Dump.Manager.service
* org.open_power.Dump.Manager.service - OpenPOWER Dump Manager Host Loaded: loaded (/lib/systemd/system/org.open_power.Dump.Manager.service; enabled; preset: enabled)
     Active: active (running) since Thu 2023-02-23 07:38:42 UTC; 26s ago
   Main PID: 997 (openpower-dump-)
     CGroup: /system.slice/org.open_power.Dump.Manager.service
             `-997 /usr/bin/openpower-dump-manager

Feb 23 07:38:42 p10bmc systemd[1]: Starting OpenPOWER Dump Manager Host...
Feb 23 07:38:42 p10bmc systemd[1]: Started OpenPOWER Dump Manager Host.


Change-Id: I13e4b18ce23746b882598a5f0d93faa108b4761f