### PR TITLE
Making the openpower-dump-manager a dummy service

### DIFF
--- a/dump/argument.cpp
+++ b/dump/argument.cpp
@@ -55,8 +55,8 @@ void ArgumentParser::usage(char** argv)
     std::cerr << "Options:\n";
     std::cerr << "    --help            Print this menu\n";
     std::cerr << "    --type            type of dump\n";
-    std::cerr
-        << "                      Valid types:0 - Hardware, 5 - Hostboot \n";
+    std::cerr << "                      Valid types:1 - Hardware, 3 - "
+                 "Performance 5 - Hostboot 10 - SBE \n";
     std::cerr << "    --id              Id of the dump\n";
     std::cerr << "    --path            path to store dump\n";
     std::cerr << "    --failingunit     Id of the failing unit\n";

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -21,76 +21,40 @@ namespace dump
 {
 
 constexpr auto DUMP_CREATE_IFACE = "xyz.openbmc_project.Dump.Create";
-constexpr auto MAX_ERROR_LOG_ID = 0xFFFFFFFF;
+// constexpr auto MAX_ERROR_LOG_ID = 0xFFFFFFFF;
 
 // Maximum possible processors in an OpenPOWER system
-constexpr auto MAX_FAILING_UNIT = 0x20;
+// constexpr auto MAX_FAILING_UNIT = 0x20;
 constexpr auto ERROR_DUMP_DISABLED =
     "xyz.openbmc_project.Dump.Create.Error.Disabled";
 constexpr auto ERROR_DUMP_QUOTA_EXCEEDED =
     "xyz.openbmc_project.Dump.Create.Error.QuotaExceeded";
 constexpr auto ERROR_DUMP_NOT_ALLOWED =
     "xyz.openbmc_project.Common.Error.NotAllowed";
-constexpr auto OP_SBE_FILES_PATH = "plat_dump";
-constexpr auto DUMP_NOTIFY_IFACE = "xyz.openbmc_project.Dump.NewDump";
-constexpr auto DUMP_PROGRESS_IFACE = "xyz.openbmc_project.Common.Progress";
-constexpr auto STATUS_PROP = "Status";
 
-/* @struct DumpTypeInfo
- * @brief to store basic info about different dump types
- */
-struct DumpTypeInfo
-{
-    std::string dumpPath;           // D-Bus path of the dump
-    std::string dumpCollectionPath; // Path were dumps are stored
-};
-/* Map of dump type to the basic info of the dumps */
-std::unordered_map<uint8_t, DumpTypeInfo> dumpInfo = {
-    {SBE::SBE_DUMP_TYPE_HOSTBOOT,
-     {HB_DUMP_DBUS_OBJPATH, HB_DUMP_COLLECTION_PATH}},
-    {SBE::SBE_DUMP_TYPE_HARDWARE,
-     {HW_DUMP_DBUS_OBJPATH, HW_DUMP_COLLECTION_PATH}},
-    {SBE::SBE_DUMP_TYPE_SBE,
-     {SBE_DUMP_DBUS_OBJPATH, SBE_DUMP_COLLECTION_PATH}}};
+std::unordered_map<std::string, std::string> dumpTypeMap = {
+    {"com.ibm.Dump.Create.DumpType.Hostboot", HB_DUMP_DBUS_OBJPATH},
+    {"com.ibm.Dump.Create.DumpType.Hardware", HW_DUMP_DBUS_OBJPATH},
+    {"com.ibm.Dump.Create.DumpType.SBE", SBE_DUMP_DBUS_OBJPATH}};
 
-std::unordered_map<std::string, uint8_t> dumpTypeMap = {
-    {"com.ibm.Dump.Create.DumpType.Hostboot", SBE::SBE_DUMP_TYPE_HOSTBOOT},
-    {"com.ibm.Dump.Create.DumpType.Hardware", SBE::SBE_DUMP_TYPE_HARDWARE},
-    {"com.ibm.Dump.Create.DumpType.SBE", SBE::SBE_DUMP_TYPE_SBE}};
-
-/* @struct DumpData
- * @brief To store the data for notifying the status of dump
- */
-struct DumpData
-{
-    uint32_t id;
-    uint8_t type;
-    std::string pathStr;
-    DumpData(uint32_t id, uint8_t type, std::string pathStr) :
-        id(id), type(type), pathStr(pathStr)
-    {}
-};
-
-sdbusplus::message::object_path Manager::createDumpEntry(DumpParams& dparams)
+sdbusplus::message::object_path
+    Manager::createDump(DumpCreateParams createParams)
 {
     using namespace phosphor::logging;
     sdbusplus::message::object_path newDumpPath;
+    auto dumpPath = extractDumpPath(createParams);
+    log<level::INFO>(
+        fmt::format("Request to collect dump({})", dumpPath).c_str());
     try
     {
         // Pass empty create parameters since no additional parameters
         // are needed.
-        util::DumpCreateParams createDumpParams;
-        auto dumpManager = util::getService(
-            bus, DUMP_CREATE_IFACE, dumpInfo[dparams.dumpType].dumpPath);
-        auto method = bus.new_method_call(
-            dumpManager.c_str(), dumpInfo[dparams.dumpType].dumpPath.c_str(),
-            DUMP_CREATE_IFACE, "CreateDump");
-        method.append(createDumpParams);
+        auto dumpManager = util::getService(bus, DUMP_CREATE_IFACE, dumpPath);
+        auto method = bus.new_method_call(dumpManager.c_str(), dumpPath.c_str(),
+                                          DUMP_CREATE_IFACE, "CreateDump");
+        method.append(createParams);
         auto response = bus.call(method);
         response.read(newDumpPath);
-
-        // DUMP Path format /xyz/openbmc_project/dump/<dump_type>/entry/<id>
-        dparams.id = std::stoi(newDumpPath.filename());
     }
     catch (const sdbusplus::exception::SdBusError& e)
     {
@@ -134,7 +98,7 @@ sdbusplus::message::object_path Manager::createDumpEntry(DumpParams& dparams)
     return newDumpPath;
 }
 
-void Manager::getParams(const DumpCreateParams& params, DumpParams& dparams)
+std::string Manager::extractDumpPath(DumpCreateParams& params)
 {
     using namespace phosphor::logging;
     using InvalidArgument =
@@ -161,216 +125,22 @@ void Manager::getParams(const DumpCreateParams& params, DumpParams& dparams)
                               Argument::ARGUMENT_VALUE("INVALID"));
     }
 
-    auto dumpType = std::get<std::string>(iter->second);
+    auto dumpTypeStr = std::get<std::string>(iter->second);
+    params.erase(iter);
 
-    auto dumpTypeIter = dumpTypeMap.find(dumpType);
+    auto dumpTypeIter = dumpTypeMap.find(dumpTypeStr);
     if (dumpTypeIter == dumpTypeMap.end())
     {
         log<level::ERR>(
-            fmt::format("Invalid dump type passed dumpType({}) error", dumpType)
+            fmt::format("Invalid dump type passed dumpType({}) error",
+                        dumpTypeStr)
                 .c_str());
         elog<InvalidArgument>(Argument::ARGUMENT_NAME("DUMP_TYPE"),
-                              Argument::ARGUMENT_VALUE(dumpType.c_str()));
+                              Argument::ARGUMENT_VALUE(dumpTypeStr.c_str()));
     }
 
-    dparams.dumpType = dumpTypeIter->second;
-
-    // get error log id
-    iter = params.find(
-        sdbusplus::com::ibm::Dump::server::Create::
-            convertCreateParametersToString(CreateParameters::ErrorLogId));
-    if (iter == params.end())
-    {
-        log<level::ERR>("Required argument, error log id is not passed");
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
-                              Argument::ARGUMENT_VALUE("MISSING"));
-    }
-
-    if (!std::holds_alternative<uint64_t>(iter->second))
-    {
-        // Exception will be raised if the input is not uint64
-        log<level::ERR>("An invalid error log id is passed, setting as 0");
-        report<InvalidArgument>(Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
-                                Argument::ARGUMENT_VALUE("INVALID INPUT"));
-    }
-
-    dparams.eid = std::get<uint64_t>(iter->second);
-
-    if (dparams.eid > MAX_ERROR_LOG_ID)
-    {
-        // An error will be logged if the error log id is larger than maximum
-        // value and set the error log id as 0.
-        log<level::ERR>(fmt::format("Error log id is greater than maximum({}) "
-                                    "length, setting as 0, errorid({})",
-                                    MAX_ERROR_LOG_ID, dparams.eid)
-                            .c_str());
-        report<InvalidArgument>(
-            Argument::ARGUMENT_NAME("ERROR_LOG_ID"),
-            Argument::ARGUMENT_VALUE(std::to_string(dparams.eid).c_str()));
-        dparams.eid = 0;
-    }
-
-    if ((dparams.dumpType == SBE::SBE_DUMP_TYPE_HARDWARE) ||
-        (dparams.dumpType == SBE::SBE_DUMP_TYPE_SBE))
-    {
-        iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
-                               convertCreateParametersToString(
-                                   CreateParameters::FailingUnitId));
-        if (iter == params.end())
-        {
-            log<level::ERR>("Required argument, failing unit id is not passed");
-            elog<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                                  Argument::ARGUMENT_VALUE("MISSING"));
-        }
-
-        if (!std::holds_alternative<uint64_t>(iter->second))
-        {
-            // Exception will be raised if the input is not uint64
-            log<level::ERR>("An invalid failing unit id is passed ");
-            report<InvalidArgument>(Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                                    Argument::ARGUMENT_VALUE("INVALID INPUT"));
-        }
-        dparams.failingUnit = std::get<uint64_t>(iter->second);
-
-        if (dparams.failingUnit > MAX_FAILING_UNIT)
-        {
-            log<level::ERR>(fmt::format("Invalid failing uint id: greater than "
-                                        "maximum number({}): input({})",
-                                        dparams.failingUnit, MAX_FAILING_UNIT)
-                                .c_str());
-            elog<InvalidArgument>(
-                Argument::ARGUMENT_NAME("FAILING_UNIT_ID"),
-                Argument::ARGUMENT_VALUE(
-                    std::to_string(dparams.failingUnit).c_str()));
-        }
-    }
+    return dumpTypeIter->second;
 }
 
-sdbusplus::message::object_path
-    Manager::createDump(DumpCreateParams createParams)
-{
-    using namespace phosphor::logging;
-    DumpParams dumpParams;
-    getParams(createParams, dumpParams);
-    log<level::INFO>(
-        fmt::format(
-            "Request to collect dump type({}), eid({}), failingUnit({})",
-            dumpParams.dumpType, dumpParams.eid, dumpParams.failingUnit)
-            .c_str());
-
-    auto dumpEntry = createDumpEntry(dumpParams);
-
-    // Initiating a BMC dump
-    log<level::INFO>(fmt::format("Initiating a BMC dump for host dump({})",
-                                 std::string(dumpEntry))
-                         .c_str());
-    openpower::dump::util::requestBMCDump();
-
-    pid_t pid = fork();
-    if (pid == 0)
-    {
-        std::filesystem::path dumpPath(
-            dumpInfo[dumpParams.dumpType].dumpCollectionPath);
-        dumpPath /= std::to_string(dumpParams.id);
-        dumpPath /= OP_SBE_FILES_PATH;
-        util::prepareCollection(dumpPath, std::to_string(dumpParams.eid));
-        execl("/usr/bin/dump-collect", "dump-collect", "--type",
-              std::to_string(dumpParams.dumpType).c_str(), "--id",
-              std::to_string(dumpParams.id).c_str(), "--path", dumpPath.c_str(),
-              "--failingunit", std::to_string(dumpParams.failingUnit).c_str(),
-              static_cast<char*>(0));
-        log<level::ERR>(
-            fmt::format("Failed to start collection error({})", errno).c_str());
-        std::exit(EXIT_FAILURE);
-    }
-    else if (pid < 0)
-    {
-        // Fork failed
-        log<level::ERR>("Failure in fork call");
-        throw std::runtime_error("Failure in fork call");
-    }
-    else
-    {
-        using InternalFailure =
-            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
-        log<level::ERR>(
-            fmt::format("Adding handler for id({}), type({}), pid({})",
-                        dumpParams.id, dumpParams.dumpType, pid)
-                .c_str());
-
-        DumpData data(dumpParams.id, dumpParams.dumpType, dumpEntry);
-        // callback
-        Child::Callback callback = [this, data, pid](Child&,
-                                                     const siginfo_t* si) {
-            using namespace phosphor::logging;
-            using InternalFailure =
-                sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
-            log<level::INFO>(
-                fmt::format("Updating status of path({})", data.pathStr)
-                    .c_str());
-            auto bus = sdbusplus::bus::new_system();
-            try
-            {
-                if (si->si_status == 0)
-                {
-                    log<level::INFO>("Dump collected, initiating packaging");
-                    auto dumpManager = util::getService(
-                        bus, DUMP_NOTIFY_IFACE, dumpInfo[data.type].dumpPath);
-                    auto method = bus.new_method_call(
-                        dumpManager.c_str(),
-                        dumpInfo[data.type].dumpPath.c_str(), DUMP_NOTIFY_IFACE,
-                        "Notify");
-                    method.append(static_cast<uint32_t>(data.id),
-                                  static_cast<uint64_t>(0));
-                    bus.call_noreply(method);
-                }
-                else
-                {
-                    log<level::ERR>("Dump collection failed, updating status");
-                    util::setProperty(DUMP_PROGRESS_IFACE, STATUS_PROP,
-                                      data.pathStr, bus,
-                                      std::variant<std::string>(
-                                          "xyz.openbmc_project.Common.Progress."
-                                          "OperationStatus.Failed"));
-                }
-            }
-            catch (const InternalFailure& e)
-            {
-                commit<InternalFailure>();
-            }
-            catch (const sdbusplus::exception::exception& e)
-            {
-                log<level::ERR>(fmt::format("Unable to update the dump status, "
-                                            "errorMsg({}) path({})",
-                                            e.what(), data.pathStr)
-                                    .c_str());
-                commit<InternalFailure>();
-            }
-
-            this->childPtrMap.erase(pid);
-        };
-
-        try
-        {
-            childPtrMap.emplace(pid,
-                                std::make_unique<Child>(eventLoop.get(), pid,
-                                                        WEXITED | WSTOPPED,
-                                                        std::move(callback)));
-        }
-        catch (const sdeventplus::SdEventError& ex)
-        {
-            // Failed to add to event loop
-            log<level::ERR>(
-                fmt::format(
-                    "Error occurred during the  sdeventplus::source::Child "
-                    "call, ex({})",
-                    ex.what())
-                    .c_str());
-            elog<InternalFailure>();
-        }
-    }
-
-    return dumpEntry;
-}
 } // namespace dump
 } // namespace openpower

--- a/dump/dump_manager.hpp
+++ b/dump/dump_manager.hpp
@@ -2,8 +2,6 @@
 
 #include <com/ibm/Dump/Create/server.hpp>
 #include <sdbusplus/bus.hpp>
-#include <sdeventplus/source/child.hpp>
-#include <sdeventplus/source/event.hpp>
 #include <xyz/openbmc_project/Dump/Create/server.hpp>
 
 #include <map>
@@ -12,35 +10,12 @@ namespace openpower
 {
 namespace dump
 {
-/* Need a custom deleter for freeing up sd_event */
-struct EventDeleter
-{
-    void operator()(sd_event* event) const
-    {
-        event = sd_event_unref(event);
-    }
-};
-
-using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
-
 using DumpCreateParams =
     std::map<std::string, std::variant<std::string, uint64_t>>;
-
-/** @struct DumpParams
- *  @brief Parameters for dump
- */
-struct DumpParams
-{
-    uint8_t dumpType;     // Type of the dump
-    uint64_t eid;         // Eid associated with dump
-    uint64_t failingUnit; // Unit failed
-    uint32_t id;          // Dump id
-};
 
 using CreateIface = sdbusplus::server::object::object<
     sdbusplus::com::ibm::Dump::server::Create,
     sdbusplus::xyz::openbmc_project::Dump::server::Create>;
-using ::sdeventplus::source::Child;
 
 /** @class Manager
  *  @brief Dump  manager class
@@ -60,10 +35,9 @@ class Manager : public CreateIface
     /** @brief Constructor to put object onto bus at a dbus path.
      *  @param[in] bus - Bus to attach to.
      *  @param[in] path - Path of the service.
-     *  @param[in] event - sd event handler.
      */
-    Manager(sdbusplus::bus::bus& bus, const char* path, const EventPtr& event) :
-        CreateIface(bus, path), bus(bus), eventLoop(event.get())
+    Manager(sdbusplus::bus::bus& bus, const char* path) :
+        CreateIface(bus, path), bus(bus)
     {}
 
     /** @brief Implementation for createDump
@@ -73,30 +47,19 @@ class Manager : public CreateIface
      *
      *  @return object_path - The object path of the new dump entry.
      */
-    sdbusplus::message::object_path createDump(DumpCreateParams) override;
+    sdbusplus::message::object_path
+        createDump(DumpCreateParams createParams) override;
 
   private:
-    /** @brief Get the dump params from arguments
+    /** @brief Get the dump path from dump type
      *  @param[in] params - Parameters for creating the dump.
-     *  @param[out] dparams - Dump parameter struct with values
-     */
-    void getParams(const DumpCreateParams& params, DumpParams& dparams);
-
-    /** @brief Create the entry for the dump
-     *  @param[in] dparams - Dump parameter struct with values
      *
-     *   @return object_path - The object path of the new dump entry
+     *  @return D-Bus path for creating dump
      */
-    sdbusplus::message::object_path createDumpEntry(DumpParams& dparams);
+    std::string extractDumpPath(DumpCreateParams& param);
 
     /** @brief sdbusplus DBus bus connection. */
     sdbusplus::bus::bus& bus;
-
-    /** @brief sdbusplus Dump event loop */
-    EventPtr eventLoop;
-
-    /** @brief map of SDEventPlus child pointer added to event loop */
-    std::map<pid_t, std::unique_ptr<Child>> childPtrMap;
 };
 
 } // namespace dump

--- a/dump/dump_manager_main.cpp
+++ b/dump/dump_manager_main.cpp
@@ -1,66 +1,23 @@
 #include "config.h"
 
 #include "dump_manager.hpp"
-#include "xyz/openbmc_project/Common/error.hpp"
 
-#include <fmt/core.h>
-
-#include <phosphor-logging/elog-errors.hpp>
 #include <sdbusplus/bus.hpp>
 
 int main()
 {
-    using namespace phosphor::logging;
-    using InternalFailure =
-        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
-
     auto bus = sdbusplus::bus::new_default();
-    sd_event* event = nullptr;
-    auto rc = sd_event_default(&event);
-    if (rc < 0)
-    {
-        log<level::ERR>(
-            fmt::format("Error occurred during the sd_event_default, rc({})",
-                        rc)
-                .c_str());
-        report<InternalFailure>();
-        return rc;
-    }
-    openpower::dump::EventPtr eventP{event};
-    event = nullptr;
-
-    // Blocking SIGCHLD is needed for calling sd_event_add_child
-    sigset_t mask;
-    if (sigemptyset(&mask) < 0)
-    {
-        log<level::ERR>(
-            fmt::format("Unable to initialize signal set, errno({})", errno)
-                .c_str());
-        return EXIT_FAILURE;
-    }
-
-    if (sigaddset(&mask, SIGCHLD) < 0)
-    {
-        log<level::ERR>(
-            fmt::format("Unable to add signal to signal set, errno({})", errno)
-                .c_str());
-        return EXIT_FAILURE;
-    }
-
-    // Block SIGCHLD first, so that the event loop can handle it
-    if (sigprocmask(SIG_BLOCK, &mask, nullptr) < 0)
-    {
-        log<level::ERR>(
-            fmt::format("Unable to block signal, errno({})", errno).c_str());
-        return EXIT_FAILURE;
-    }
 
     // Add sdbusplus ObjectManager for the 'root' path of the DUMP manager.
     sdbusplus::server::manager::manager objManager(bus, OP_DUMP_OBJPATH);
     bus.request_name(OP_DUMP_BUSNAME);
 
-    openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH, eventP);
+    openpower::dump::Manager mgr(bus, OP_DUMP_OBJPATH);
 
-    bus.attach_event(eventP.get(), SD_EVENT_PRIORITY_NORMAL);
-    return sd_event_loop(eventP.get());
+    while (true)
+    {
+        bus.process_discard();
+        bus.wait();
+    }
+    exit(EXIT_SUCCESS);
 }

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -87,12 +87,6 @@ void setProperty(const std::string& interface, const std::string& propertyName,
     auto reply = bus.call(method);
 }
 
-/** @brief create dump directories and add error log id
- *  @param dumpPath Directory for collecting dump
- *  @errorLogId Error log id associated with dump
- */
-void prepareCollection(const std::filesystem::path& dumpPath,
-                       const std::string& errorLogId);
 /**
  * Request SBE dump from the dump manager
  *
@@ -103,12 +97,6 @@ void prepareCollection(const std::filesystem::path& dumpPath,
  * @param eid Error log id associated with dump
  */
 void requestSBEDump(const uint32_t failingUnit, const uint32_t eid);
-
-/**
- * Request BMC dump from dump manager
- *
- */
-void requestBMCDump();
 
 } // namespace util
 } // namespace dump


### PR DESCRIPTION
openpower-dump-manager will be a proxy until the clients change the code to call phosphor-dump-manager

https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/62129/

Minor fix to performance dump to include that in the help
https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/59067/