### PR TITLE
Update Host Watchdog timeout event name

### DIFF
--- a/dump/dist/meson.build
+++ b/dump/dist/meson.build
@@ -1,12 +1,12 @@
 systemd_system_unit_dir = systemd_dep.get_variable(
     pkgconfig:'systemdsystemunitdir')
-conf_data = configuration_data()
-conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
+dist_conf_data = configuration_data()
+dist_conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
 
 configure_file(
   input: 'org.open_power.Dump.Manager.service.in',
   output: 'org.open_power.Dump.Manager.service',
-  configuration: conf_data,
+  configuration: dist_conf_data,
   install: true,
   install_dir: systemd_system_unit_dir)
 

--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,8 @@ else
     extra_deps = []
 endif
 
+configure_file(output: 'config.h', configuration: conf_data)
+
 deps = [
     systemd,
     sdbusplus_dep,
@@ -123,7 +125,6 @@ endif
 
 executable('watchdog_timeout',
     'watchdog_timeout.cpp',
-    configure_file(output: 'config.h', configuration: conf_data),
     generated_sources,
     dependencies: deps,
     link_with: watchdog_lib,

--- a/watchdog/watchdog_logging.cpp
+++ b/watchdog/watchdog_logging.cpp
@@ -21,7 +21,7 @@ void event(std::map<std::string, std::string>& additional,
            const uint32_t timeout)
 {
 
-    std::string eventName = "org.open_power.Host.Boot.Error.WatchdogTimeout";
+    std::string eventName = "org.open_power.Host.Boot.Error.WatchdogTimedOut";
 
     // CreatePELWithFFDCFiles requires a vector of FFDCTuple.
     auto emptyFfdc = std::vector<FFDCTuple>{};

--- a/watchdog_timeout.cpp
+++ b/watchdog_timeout.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
     {
         log<level::ERR>(fmt::format("Exception {} occurred", e.what()).c_str());
         std::string eventType =
-            "org.open_power.Processor.Error.WatchdogTimeout";
+            "org.open_power.Host.Boot.Error.WatchdogTimedOut";
         auto ffdc = std::vector<FFDCTuple>{};
         std::map<std::string, std::string> additionalData;
 


### PR DESCRIPTION
Update host watch dog timeout event name to match in both hostboot-dump-collection enabled and disabled state.
Move the configuration file generation outside the executable block

Upstream links:
https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/62812
https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/62813

Test:
Tested and creates the expected PEL.
