### PR TITLE
Functional state check removed in dump collection

### DIFF
--- a/watchdog/ffdc_file.cpp
+++ b/watchdog/ffdc_file.cpp
@@ -1,7 +1,7 @@
 #include "ffdc_file.hpp"
 
-#include <errno.h> // for errno
-#include <fcntl.h> // for open()
+#include <errno.h>     // for errno
+#include <fcntl.h>     // for open()
 #include <fmt/format.h>
 #include <string.h>    // for strerror()
 #include <sys/stat.h>  // for open()


### PR DESCRIPTION
In the current dump collection strategy, the collection process checks the functional state of the processor, and skips the collection if it is non-functional.
This can cause complications during a hostboot
dump collection if the primary booting processor
is non-functional, resulting in the halting of
the collection and an error being returned.

This approach is not optimal as the SBE can
be accessed even if the processor is non-functional, and the SBE's availability is already checked before the dump collection is initiated.

With this commit, the functional state check before the dump collection is eliminated. However, the check is retained before stopping instructions during a
hostboot dump collection, to avoid potential errors when trying to halt instructions on an inactive processor.

Change-Id: I0beacaa3172d0e6a430519adf1dabce813bc8ecd