### PR TITLE
SBE Extract RC code handling added

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -154,7 +154,8 @@ void collectDumpFromSBE(struct pdbg_target* proc,
         std::string event = "org.open_power.Processor.Error.SbeChipOpFailure";
         auto dumpIsRequired = false;
 
-        if (sbeError.errType() == openpower::phal::exception::SBE_CMD_TIMEOUT)
+        if (sbeError.errType() == openpower::phal::exception::SBE_CMD_TIMEOUT ||
+            sbeError.errType() == openpower::phal::exception::SBE_EXTRACT_RC)
         {
             event = "org.open_power.Processor.Error.SbeChipOpTimeout";
             dumpIsRequired = true;

--- a/watchdog/watchdog_main.cpp
+++ b/watchdog/watchdog_main.cpp
@@ -100,7 +100,8 @@ void handleSbeBootError(struct pdbg_target* procTarget, const uint32_t timeout)
     // event type
     std::string event;
     if ((sbeError.errType() == exception::SBE_FFDC_NO_DATA) ||
-        (sbeError.errType() == exception::SBE_CMD_TIMEOUT) || (dumpIsRequired))
+        (sbeError.errType() == exception::SBE_CMD_TIMEOUT) ||
+        (sbeError.errType() == exception::SBE_EXTRACT_RC) || (dumpIsRequired))
     {
         log<level::INFO>("No FFDC data");
         event = "org.open_power.Processor.Error.SbeBootTimeout";


### PR DESCRIPTION
In case of a dead or non responsive SBE we are now calling SBE Extract RC HWP to fill up the FFDC/Debug data. These changes are in line with that to handle the return value code in case SBE Extract RC HWP was been called up in the code flow.

Test Results: Yet to be tested