### PR TITLE
1050: support meson level in yocto 1050-ghe

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
 project(
     'openpower-debug-collector',
     'cpp',
-    meson_version: '>=1.1.1',
+    meson_version: '>=1.0.0',
     default_options: [
         'warning_level=3',
         'werror=true',
-        'cpp_std=c++23'
+        'cpp_std=c++20'
     ],
     license: 'Apache-2.0',
     version: '1.0.0',

--- a/watchdog/watchdog_main.cpp
+++ b/watchdog/watchdog_main.cpp
@@ -67,7 +67,7 @@ void triggerSystemDump()
     catch (const sdbusplus::exception::SdBusError& e)
     {
         log<level::ERR>(
-            std::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
+            fmt::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
                         e.what())
                 .c_str());
     }


### PR DESCRIPTION
Our 1050-ghe level only has yocto 1.0.0 and c++20 so be sure to support that in this projects 1050 branch.