### PR TITLE
1060: watchdog:Trigger System Dump when host load fails

### DIFF
--- a/watchdog/watchdog_main.hpp
+++ b/watchdog/watchdog_main.hpp
@@ -26,5 +26,13 @@ void triggerHostbootDump(const uint32_t timeout);
  */
 void handleSbeBootError(struct pdbg_target* procTarget, const uint32_t timeout);
 
+/**
+ * @brief creates a PEL and triggers System dump
+ *
+ * @details This function creates the PEL and then triggers System dump
+ *
+ */
+void triggerSystemDump();
+
 } // namespace dump
 } // namespace watchdog

--- a/watchdog_timeout.cpp
+++ b/watchdog_timeout.cpp
@@ -65,9 +65,22 @@ int main(int argc, char* argv[])
                 return EXIT_SUCCESS;
             }
 
-            // SBE boot done, Need to collect hostboot dump
-            log<level::INFO>("Handle Hostboot boot failure");
-            triggerHostbootDump(timeout);
+            // If the hostboot has transitioned to host, and there is a failure
+            // before host is loaded we will hit the below piece of code,
+            // so trigger system dump
+            if (openpower::phal::pdbg::hasControlTransitionedToHost())
+            {
+                // hostboot done, Need to collect system dump
+                log<level::INFO>(
+                    "Failure while booting host, triggering system dump");
+                triggerSystemDump();
+            }
+            else
+            {
+                // SBE boot done, Need to collect hostboot dump
+                log<level::INFO>("Handle Hostboot boot failure");
+                triggerHostbootDump(timeout);
+            }
         }
         else
         {


### PR DESCRIPTION
#### watchdog:Trigger System Dump when host load fails
```
Using the xyz.openbmc_project.State.Host interface to determine the
operational status of the host becomes less precise when shifting from
hostboot to host. In the interim phase when host is initializing and
hasn't reached full functionality, the host's state is inaccurately
assumed to be in hostboot. In cases where host encounters initial boot
challenges and the watchdog timer triggers because the boot process
hasn't finished within the set time, this watchdog misinterprets the
situation as a hostboot problem.

To address this, there exists a core scratch register that undergoes an
update by hostboot just before transferring control to host. We have
devised a method that leverages this register to determine whether the
transition to host has already occurred.

By implementing this functionality we can determine which booting
subsystem is failed or stopped responding, and the dump can be extracted
from the right subsystem

Tested:
Oct 03 09:35:36 p10bmc watchdog_timeout[7099]: Host did not respond within watchdog timeout interval
Oct 03 09:35:36 p10bmc watchdog_timeout[7099]: PHYP boot failure, triggering system dump
Oct 03 09:35:37 p10bmc phosphor-log-manager[372]: Created PEL 0x50001924 (BMC ID 252) with SRC BD5EC101
Oct 03 09:35:37 p10bmc ibm-panel[1208]: Resolution is empty for PEL = /xyz/openbmc_project/logging/entry/252
Oct 03 09:35:37 p10bmc phosphor-host-state-manager[795]: Received signal that host has crashed, decrement reboot count
...
...
...
Oct 03 09:35:38 p10bmc systemd[1]: Starting Start memory preserving reboot host0...
Oct 03 09:35:38 p10bmc pldmd[719]: BIOS:pvm_sys_dump_active, updated to value: Enabled(16), by BMC: true
Oct 03 09:35:38 p10bmc phosphor-dump-manager[473]: OriginatorId is not provided
Oct 03 09:35:38 p10bmc phosphor-dump-manager[473]: OriginatorType is not provided. Replacing the string with the default value
Oct 03 09:35:38 p10bmc sh[7151]: o "/xyz/openbmc_project/dump/bmc/entry/2"
Oct 03 09:35:38 p10bmc openpower-proc-control[7153]: Starting memory preserving reboot

PEL:
root@p10bmc:~# peltool -i 0x50001924
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc system dump collector",
    "Created at":               "10/03/2023 09:35:36",
    "Committed at":             "10/03/2023 09:35:37",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50001924",
    "Entry Id":                 "0x50001924",
    "BMC Event Log Id":         "252"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware - Hostboot-Service Processor Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Unrecoverable Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc system dump collector",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Host did not respond before the watchdog timeout interval expired"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD5EC101",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "CC009544",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-42A",
    "Reporting Serial Number":  "13BE960",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1050.00-8",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD5EC101_2E2F0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-42A",
    "Serial Number":            "13BE960"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.56 0.90 0.98",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 8h 49m 24s",
    "BootState": "Unspecified",
    "ChassisState": "On",
    "FW Version ID": "fw1050.00-8",
    "HostState": "Running",
    "Process Name": "/usr/bin/watchdog_timeout",
    "System IM": "50001000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "_PID": "7099"
}
}

Change-Id: I312ad7201e9258d23f6e784fab504d0fb8f0f712
Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>
```