### PR TITLE
Fix CI Failure

### DIFF
--- a/watchdog/watchdog_main.cpp
+++ b/watchdog/watchdog_main.cpp
@@ -67,7 +67,7 @@ void triggerSystemDump()
     catch (const sdbusplus::exception::SdBusError& e)
     {
         log<level::ERR>(
-            std::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
+            fmt::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
                         e.what())
                 .c_str());
     }


### PR DESCRIPTION
Use the fmt::format library call that is supported

Change-Id: I4fee2129f1d07ec1eda6555be91e8214f2822e5c
Signed-off-by: Parasa Swetha <parasa.swetha1@ibm.com>