### PR TITLE
Fix CI Failure

### DIFF
--- a/watchdog/watchdog_main.cpp
+++ b/watchdog/watchdog_main.cpp
@@ -67,7 +67,7 @@ void triggerSystemDump()
     catch (const sdbusplus::exception::SdBusError& e)
     {
         log<level::ERR>(
-            std::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
+            fmt::format("triggerMPIPLDump:: D-Bus call exception, errorMsg({})",
                         e.what())
                 .c_str());
     }


### PR DESCRIPTION
Use the fmt::format library call that is supported

Change-Id: I55120c1b83c7ab50b072b8d32d4fbbed4422418c
Signed-off-by: Parasa Swetha <parasa.swetha1@ibm.com>