### PR TITLE
Support for HW dump from Odyssey

### DIFF
--- a/dump/dump_collect.hpp
+++ b/dump/dump_collect.hpp
@@ -18,10 +18,11 @@ namespace sbe_chipop
  *  @param chipPos - Chip position of the failing unit
  *  @param dataPtr - Content to write to file
  *  @param len - Length of the content
+ *  @param[in] isOcmb - Whther dump is collected from OCMB chip
  */
 void writeDumpFile(const std::filesystem::path& path, const uint32_t id,
                    const uint8_t clockState, const uint8_t chipPos,
-                   util::DumpDataPtr& dataPtr, const uint32_t len);
+                   util::DumpDataPtr& dataPtr, const uint32_t len, bool isOcmb);
 
 /** @brief The function to orchestrate dump collection from different
  *  SBEs


### PR DESCRIPTION
This commit introduces the functionality to support hardware dump
 collection in Odyssey systems. The implementation includes
necessary modifications to the dump manager to handle Odessey
specific changes to collect dumps from SBE.

Tests:

busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.Hardware" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/hardware/entry/14";
};

ec 13 05:58:38 ever6bmc dump-collect[7758]: Dump collection completed for clock_state(2)
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.ocmb2
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.ocmb3
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc0
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc1
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc2
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc3
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc4
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc5
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc6
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOff.node0.proc7
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.ocmb2
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.ocmb3
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc0
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc1
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc2
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc3
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc4
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc5
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc6
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: plat_dump/00000014.SbeDataClocksOn.node0.proc7
Dec 13 05:58:41 ever6bmc phosphor-dump-manager[8001]: info.yaml