### PR TITLE
dump: use pdbg method to check target is of ody ocmb

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -95,7 +95,7 @@ void collectDumpFromSBE(struct pdbg_target* chip,
 {
     using namespace phosphor::logging;
     auto chipPos = pdbg_target_index(chip);
-    bool isOcmb = openpower::phal::sbe::is_ody_ocmb_chip(chip);
+    bool isOcmb = is_ody_ocmb_chip(chip);
     std::string chipName = isOcmb ? "ocmb" : "proc";
     log<level::INFO>(std::format("Collect dump from ({})({}) path({}) id({}) "
                                  "type({}) clock({}) failingUnit({})",
@@ -303,7 +303,7 @@ void collectDump(const uint8_t type, const uint32_t id,
                     continue;
                 }
 
-                if (!openpower::phal::sbe::is_ody_ocmb_chip(ocmbTarget))
+                if (!is_ody_ocmb_chip(ocmbTarget))
                 {
                     continue;
                 }


### PR DESCRIPTION
Use the newly added api in pdbg to check if the pdbg target is of ocmb and is of ddr5 ody.


Change-Id: I8209743f143c9d99fda509045e814839fbb7817a