### PR TITLE
POZ: check for ody target and then probe

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -96,7 +96,7 @@ void collectDumpFromSBE(struct pdbg_target* chip,
 {
     using namespace phosphor::logging;
     auto chipPos = pdbg_target_index(chip);
-    bool isOcmb = openpower::phal::sbe::is_ody_ocmb_chip(chip);
+    bool isOcmb = is_ody_ocmb_chip(chip);
     std::string chipName = isOcmb ? "ocmb" : "proc";
     log<level::INFO>(std::format("Collect dump from ({})({}) path({}) id({}) "
                                  "type({}) clock({}) failingUnit({})",
@@ -316,12 +316,11 @@ void collectDump(const uint8_t type, const uint32_t id,
             struct pdbg_target* ocmbTarget;
             pdbg_for_each_target("ocmb", target, ocmbTarget)
             {
-                if (pdbg_target_probe(ocmbTarget) != PDBG_TARGET_ENABLED)
+                if (!is_ody_ocmb_chip(ocmbTarget))
                 {
                     continue;
                 }
-
-                if (!openpower::phal::sbe::is_ody_ocmb_chip(ocmbTarget))
+                if (pdbg_target_probe(ocmbTarget) != PDBG_TARGET_ENABLED)
                 {
                     continue;
                 }


### PR DESCRIPTION
While looping through ocmb targets check if it is ody target and then do probe, or else we will be probing all the ocmb targets for which we do not intend to collect dump

Change-Id: I55d7448b446cb0052a24ee2f3b7ef2e1f093e670