### PR TITLE
Fix for fast array collection

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -177,17 +177,12 @@ void collectDumpFromSBE(struct pdbg_target* chip,
         auto logId = openpower::dump::pel::createSbeErrorPEL(event, sbeError,
                                                              pelAdditionalData);
 
-        // TODO: requestSBEDump is not yet catered for ody
-        if (isOcmb)
-        {
-            return;
-        }
         if (dumpIsRequired)
         {
             // Request SBE Dump
             try
             {
-                util::requestSBEDump(chipPos, logId);
+                util::requestSBEDump(chipPos, logId, isOcmb);
             }
             catch (const std::exception& e)
             {

--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -109,7 +109,7 @@ void collectDumpFromSBE(struct pdbg_target* chip,
     uint8_t collectFastArray = 0;
     if (clockState == SBE::SBE_CLOCK_OFF)
     {
-        if ((type == SBE::SBE_DUMP_TYPE_HOSTBOOT) ||
+        if ((type == SBE::SBE_DUMP_TYPE_HOSTBOOT) || (isOcmb) ||
             ((type == SBE::SBE_DUMP_TYPE_HARDWARE) && (chipPos == failingUnit)))
         {
             collectFastArray = 1;

--- a/dump/dump_utils.cpp
+++ b/dump/dump_utils.cpp
@@ -100,15 +100,20 @@ void monitorDump(const std::string& path, const uint32_t timeout)
     }
 }
 
-void requestSBEDump(const uint32_t failingUnit, const uint32_t eid)
+void requestSBEDump(const uint32_t failingUnit, const uint32_t eid, bool isOcmb)
 {
     log<level::INFO>(std::format("Requesting Dump PEL({}) chip position({})",
                                  eid, failingUnit)
                          .c_str());
 
-    constexpr auto path = "/xyz/openbmc_project/dump/sbe";
+    std::string path = "/xyz/openbmc_project/dump/sbe";
     constexpr auto interface = "xyz.openbmc_project.Dump.Create";
     constexpr auto function = "CreateDump";
+
+    if (isOcmb)
+    {
+        path = "/xyz/openbmc_project/dump/msbe";
+    }
 
     sdbusplus::message::message method;
 
@@ -117,8 +122,8 @@ void requestSBEDump(const uint32_t failingUnit, const uint32_t eid)
     try
     {
         auto service = getService(bus, interface, path);
-        auto method = bus.new_method_call(service.c_str(), path, interface,
-                                          function);
+        auto method = bus.new_method_call(service.c_str(), path.c_str(),
+                                          interface, function);
 
         // dbus call arguments
         std::unordered_map<std::string, std::variant<std::string, uint64_t>>

--- a/dump/dump_utils.hpp
+++ b/dump/dump_utils.hpp
@@ -95,8 +95,10 @@ void setProperty(const std::string& interface, const std::string& propertyName,
  *
  * @param failingUnit The id of the proc containing failed SBE
  * @param eid Error log id associated with dump
+ * @param isOcmb if true collect dump from OCMB SBE
  */
-void requestSBEDump(const uint32_t failingUnit, const uint32_t eid);
+void requestSBEDump(const uint32_t failingUnit, const uint32_t eid,
+                    bool isOcmb = false);
 
 } // namespace util
 } // namespace dump


### PR DESCRIPTION
- Need to collect fast arrays from all OCMB chips during HW dump collection
- Initiate OCMB SBE dump in the case of a chipop timeout