### PR TITLE
Log all PELs as informational

### DIFF
--- a/dump/create_pel.cpp
+++ b/dump/create_pel.cpp
@@ -135,6 +135,15 @@ void processFFDCPackets(const openpower::phal::sbeError_t& sbeError,
 
         Severity logSeverity = convertSeverityToEnum(severity);
 
+        if (logSeverity != openpower::dump::pel::Severity::Informational)
+        {
+            lg2::info(
+                "Changing severity from {SEV_ORIG} to informational in the "
+                "dumping path",
+                "SEV_ORIG", logSeverity);
+            logSeverity = openpower::dump::pel::Severity::Informational;
+        }
+
         PELFFDCInfo pelFFDCInfo;
         pelFFDCInfo.emplace_back(
             std::make_tuple(sdbusplus::xyz::openbmc_project::Logging::server::

--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -205,7 +205,7 @@ bool SbeDumpCollector::logErrorAndCreatePEL(
 
         // Common FFDC data
         openpower::dump::pel::FFDCData pelAdditionalData = {
-            {"SRC6", std::format("{:X}{:X}", chipPos, (cmdClass | cmdType))}};
+            {"SRC6", std::format("0x{:X}{:X}", chipPos, (cmdClass | cmdType))}};
 
         if (sbeType == SBETypes::OCMB)
         {


### PR DESCRIPTION
Hardware failure dumps or boot failure dumps are collected when the systems are in a critically bad state. Additional errors that occur during the dump collection may be side effects of the prior failures. Thus, logging all such errors as informational helps avoid unwanted alerts.

Tests:
WIthout change
    "0x50002C17": {
        "SRC":                  "BD123500",
        "Message":              "chipop request failure reported by SBE",
        "PLID":                 "0x50002C17",
        "CreatorID":            "BMC",
        "Subsystem":            "Processor Chip Cache",
        "Commit Time":          "05/03/2024 15:27:09",
        "Sev":                  "Unrecoverable Error",
        "CompID":               "bmc common host processor errors"
    },
    
    With change

root@ever6bmc:/tmp# peltool --info -l -h
{
    "0x50002C27": {
        "SRC":                  "BD123500",
        "Message":              "chipop request failure reported by SBE",
        "PLID":                 "0x50002C27",
        "CreatorID":            "BMC",
        "Subsystem":            "Processor Chip Cache",
        "Commit Time":          "05/03/2024 15:32:31",
        "Sev":                  "Informational Event",
        "CompID":               "bmc common host processor errors"
    },

Change-Id: Ie00d7689fcdae4ac1398f3bda36ecc581b305a95