### PR TITLE
Dump collection support in 1110

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -1,0 +1,1 @@
+dump/tools/common/include/gendumpheader

--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -1,2 +1,3 @@
 dump/tools/common/include/gendumpheader
 dump/tools/opdump/opdreport
+dump/tools/common/include/gendumpinfo

--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -1,1 +1,2 @@
 dump/tools/common/include/gendumpheader
+dump/tools/opdump/opdreport

--- a/dump/dist/meson.build
+++ b/dump/dist/meson.build
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+systemd_dep = dependency('systemd', required: true)
+
+systemd_system_unit_dir = systemd_dep.get_variable(
+    pkgconfig: 'systemdsystemunitdir'
+)
+dist_conf_data = configuration_data()
+dist_conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
+
+# Service installation
+configure_file(
+  input: 'openpower-dump-monitor.service',
+  output: 'openpower-dump-monitor.service',
+  configuration: dist_conf_data,
+  install: true,
+  install_dir: systemd_system_unit_dir
+)
+
+# Symlinks for services
+systemd_alias = [
+    ['../openpower-dump-monitor.service',
+     'obmc-host-startmin@0.target.wants/openpower-dump-monitor.service']
+]
+
+foreach service: systemd_alias
+    meson.add_install_script(
+        'sh', '-c',
+        'mkdir -p $(dirname $DESTDIR/@0@/@1@)'.format(
+            systemd_system_unit_dir, service[1]
+        ),
+    )
+    meson.add_install_script(
+        'sh', '-c',
+        'ln -s @0@ $DESTDIR/@1@/@2@'.format(
+            service[0], systemd_system_unit_dir, service[1]
+        ),
+    )
+endforeach

--- a/dump/dist/openpower-dump-monitor.service
+++ b/dump/dist/openpower-dump-monitor.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenPOWER Dump Monitor
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
+After=xyz.openbmc_project.Dump.Manager.service
+
+[Service]
+ExecStart=/usr/bin/openpower-dump-monitor
+Restart=always
+Type=simple
+
+[Install]
+# WantedBy=obmc-host-startmin@0.target

--- a/dump/dump_monitor.cpp
+++ b/dump/dump_monitor.cpp
@@ -1,0 +1,150 @@
+#include "dump_monitor.hpp"
+
+#include "dump_utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <regex>
+
+namespace openpower::dump
+{
+
+constexpr auto dumpOutPath = "/var/lib/phosphor-debug-collector/opdump";
+constexpr auto dumpStatusFailed =
+    "xyz.openbmc_project.Common.Progress.OperationStatus.Failed";
+
+void DumpMonitor::executeCollectionScript(
+    const sdbusplus::message::object_path& path, const PropertyMap& properties)
+{
+    std::vector<std::string> args = {"opdreport"};
+    std::regex idFormat("^[a-fA-F0-9]{8}$");
+    auto dumpIdStr = path.filename();
+    if (!std::regex_match(dumpIdStr, idFormat))
+    {
+        lg2::error("Failed to extract dump id from path {PATH}", "PATH", path);
+        updateProgressStatus(path, dumpStatusFailed);
+        return;
+    }
+
+    uint32_t dumpId = std::strtoul(dumpIdStr.c_str(), nullptr, 16);
+    int dumpType = getDumpTypeFromId(dumpId);
+    std::filesystem::path dumpPath = std::filesystem::path(dumpOutPath) /
+                                     dumpIdStr;
+
+    // Add type, ID, and dump path to args
+    args.push_back("-t");
+    args.push_back(std::to_string(dumpType));
+    args.push_back("-i");
+    args.push_back(dumpIdStr);
+    args.push_back("-d");
+    args.push_back(dumpPath.string());
+
+    // Optionally add ErrorLogId and FailingUnitId
+    auto errorLogIdIt = properties.find("ErrorLogId");
+    if (errorLogIdIt != properties.end())
+    {
+        uint32_t errorLogId = std::get<uint32_t>(errorLogIdIt->second);
+        args.push_back("-e");
+        args.push_back(std::to_string(errorLogId));
+    }
+
+    auto failingUnitIdIt = properties.find("FailingUnitId");
+    if (failingUnitIdIt != properties.end())
+    {
+        uint32_t failingUnitId = std::get<uint32_t>(failingUnitIdIt->second);
+        args.push_back("-f");
+        args.push_back(std::to_string(failingUnitId));
+    }
+
+    std::vector<char*> argv;
+    for (auto& arg : args)
+    {
+        argv.push_back(arg.data());
+    }
+
+    argv.push_back(nullptr);
+    pid_t pid = fork();
+    if (pid == -1)
+    {
+        lg2::error("Failed to fork, cannot collect dump, {ERRRNO}", "ERRNO",
+                   errno);
+        updateProgressStatus(path, dumpStatusFailed);
+        exit(EXIT_FAILURE); // Exit explicitly with failure status
+    }
+    else if (pid == 0)
+    {
+        // Child process
+        execvp("opdreport", argv.data());
+        perror("execvp");   // execvp only returns on error
+        updateProgressStatus(path, dumpStatusFailed);
+        exit(EXIT_FAILURE); // Exit explicitly with failure status
+    }
+    else
+    {
+        // Parent process: wait for the child to terminate
+        int status;
+        waitpid(pid, &status, 0);
+        if (WIFEXITED(status))
+        {
+            int exit_status = WEXITSTATUS(status);
+
+            if (exit_status != 0)
+            {
+                // Handle failure
+                lg2::error("Dump failed updating status {PATH}", "PATH", path);
+                updateProgressStatus(path, dumpStatusFailed);
+            }
+        }
+    }
+}
+
+void DumpMonitor::handleDBusSignal(sdbusplus::message::message& msg)
+{
+    sdbusplus::message::object_path objectPath;
+    InterfaceMap interfaces;
+
+    msg.read(objectPath, interfaces);
+
+    lg2::info("Signal received at PATH: ", "PATH", objectPath);
+
+    // There can be new a entry created after the completion of the collection
+    // with completed status, so pick only entries with InProgress status.
+    if (isInProgress(interfaces))
+    {
+        for (const auto& interfaceName : monitoredInterfaces)
+        {
+            auto it = interfaces.find(interfaceName);
+            if (it != interfaces.end())
+            {
+                lg2::info("An entry created, collecting a new dump {DUMP}",
+                          "DUMP", interfaceName);
+                executeCollectionScript(objectPath, it->second);
+            }
+        }
+    }
+}
+
+void DumpMonitor::updateProgressStatus(const std::string& path,
+                                       const std::string& status)
+{
+    auto bus = sdbusplus::bus::new_default();
+    const std::string interfaceName = "xyz.openbmc_project.Common.Progress";
+    const std::string propertyName = "Status";
+    const std::string serviceName = "xyz.openbmc_project.Dump.Manager";
+
+    try
+    {
+        auto statusVariant = std::variant<std::string>(status);
+        util::setProperty<std::variant<std::string>>(
+            interfaceName, propertyName, path, bus, statusVariant);
+        lg2::info("Status updated successfully to {STATUS} {PATH}", "STATUS",
+                  status, "PATH", path);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error("Failed to update status {STATUS} {PATH} {ERROR}", "STATUS",
+                   status, "PATH", path, "ERROR", e);
+    }
+}
+
+} // namespace openpower::dump

--- a/dump/dump_monitor.hpp
+++ b/dump/dump_monitor.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "dump_utils.hpp"
+#include "sbe_consts.hpp"
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+#include <iostream>
+#include <string>
+#include <variant>
+
+namespace openpower::dump
+{
+
+using PropertyMap = std::map<std::string, std::variant<uint32_t, std::string>>;
+using InterfaceMap = std::map<std::string, PropertyMap>;
+/**
+ * @class DumpMonitor
+ * @brief Monitors DBus signals for dump creation and handles them.
+ */
+class DumpMonitor
+{
+  public:
+    /**
+     * @brief Constructor for DumpMonitor.
+     * Initializes the DBus connection and signal match for monitoring dump
+     * creation.
+     */
+    DumpMonitor() :
+        bus(sdbusplus::bus::new_default()),
+        match(std::make_unique<sdbusplus::bus::match_t>(
+            bus,
+            sdbusplus::bus::match::rules::type::signal() +
+                sdbusplus::bus::match::rules::interface(
+                    "org.freedesktop.DBus.ObjectManager") +
+                sdbusplus::bus::match::rules::member("InterfacesAdded") +
+                sdbusplus::bus::match::rules::path_namespace(
+                    "/xyz/openbmc_project/dump") +
+                sdbusplus::bus::match::rules::sender(
+                    "xyz.openbmc_project.Dump.Manager"),
+            [this](sdbusplus::message_t& msg) { handleDBusSignal(msg); }))
+    {}
+
+    /**
+     * @brief Runs the monitor to continuously listen for DBus signals.
+     */
+    void run()
+    {
+        while (true)
+        {
+            bus.process_discard();
+            bus.wait();
+        }
+    }
+
+  private:
+    sdbusplus::bus::bus bus;
+    std::vector<std::string> monitoredInterfaces = {
+        "com.ibm.Dump.Entry.Hardware", "com.ibm.Dump.Entry.Hostboot",
+        "com.ibm.Dump.Entry.SBE"};
+    std::unique_ptr<sdbusplus::bus::match::match> match;
+
+    /**
+     * @brief Handles the received DBus signal for dump creation.
+     * @param[in] msg - The DBus message received.
+     */
+    void handleDBusSignal(sdbusplus::message::message& msg);
+
+    /**
+     * @brief Checks if the dump creation is in progress.
+     * @param[in] interfaces - The map of interfaces and their properties.
+     * @return True if the dump is in progress, false otherwise.
+     */
+    inline bool isInProgress(const InterfaceMap& interfaces)
+    {
+        auto progressIt =
+            interfaces.find("xyz.openbmc_project.Common.Progress");
+        if (progressIt != interfaces.end())
+        {
+            auto statusIt = progressIt->second.find("Status");
+            if (statusIt != progressIt->second.end())
+            {
+                std::string status = std::get<std::string>(statusIt->second);
+                return status ==
+                       "xyz.openbmc_project.Common.Progress.OperationStatus.InProgress";
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @brief Executes the script to collect the dump.
+     * @param[in] path - The object path of the dump entry.
+     * @param[in] properties - The properties of the dump entry.
+     */
+    void executeCollectionScript(const sdbusplus::message::object_path& path,
+                                 const PropertyMap& properties);
+
+    /**
+     * @brief Updates the progress status of the dump.
+     * @param[in] path - The object path of the dump entry.
+     * @param[in] status - The status to be set.
+     */
+    void updateProgressStatus(const std::string& path,
+                              const std::string& status);
+
+    /**
+     * @brief Gets the dump type from the dump ID.
+     * @param[in] id - The dump ID.
+     * @return The dump type.
+     */
+    inline uint32_t getDumpTypeFromId(uint32_t id)
+    {
+        using namespace openpower::dump::SBE;
+        uint8_t type = (id >> 28) & 0xF;
+        if (type == 0)
+        {
+            return SBE_DUMP_TYPE_HARDWARE;
+        }
+        else if (type == 2)
+        {
+            return SBE_DUMP_TYPE_HOSTBOOT;
+        }
+        else if (type == 3)
+        {
+            return SBE_DUMP_TYPE_SBE;
+        }
+        return 0;
+    }
+};
+
+} // namespace openpower::dump

--- a/dump/dump_monitor_main.cpp
+++ b/dump/dump_monitor_main.cpp
@@ -1,0 +1,15 @@
+#include "dump_monitor.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+#include <exception>
+#include <iostream>
+#include <variant>
+
+int main()
+{
+    openpower::dump::DumpMonitor monitor;
+    monitor.run();
+    return 0;
+}

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -27,3 +27,17 @@ executable('dump-collect',
     implicit_include_directories: true,
     install: true
 )
+
+bindir = get_option('bindir')
+
+scripts_to_install = [] 
+
+subdir('tools')
+# Install collected files if any
+if scripts_to_install.length() > 0
+    install_data(scripts_to_install,
+        install_dir: get_option('bindir'),
+        install_mode: 'rwxr-xr-x'
+    )
+endif
+

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -2,12 +2,20 @@
 
 cxx = meson.get_compiler('cpp')
 
+sdeventplus_dep = dependency('sdeventplus')
+
 collect_deps = [
    CLI11_dep,
    phosphorlogging,
    cxx.find_library('pdbg'),
    cxx.find_library('libdt-api'),
    cxx.find_library('phal'),
+]
+
+monitor_deps = [
+    sdbusplus_dep,
+    sdeventplus_dep,
+    phosphorlogging,
 ]
 
 # source files
@@ -21,9 +29,22 @@ collect_src = files(
     'sbe_type.cpp',
 )
 
+monitor_src = files(
+    'dump_monitor.cpp',
+    'dump_monitor_main.cpp',
+    'dump_utils.cpp',
+)
+
 executable('dump-collect',
     collect_src,
     dependencies: collect_deps,
+    implicit_include_directories: true,
+    install: true
+)
+
+executable('openpower-dump-monitor',
+    monitor_src,
+    dependencies: monitor_deps,
     implicit_include_directories: true,
     install: true
 )

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -72,4 +72,6 @@ if include_scripts.length() > 0
     )
 endif
 
+subdir('dist')
+
 

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -29,8 +29,10 @@ executable('dump-collect',
 )
 
 bindir = get_option('bindir')
+dreport_include_dir = join_paths(get_option('datadir'), 'dreport.d/include.d')
 
-scripts_to_install = [] 
+scripts_to_install = []
+include_scripts = []
 
 subdir('tools')
 # Install collected files if any
@@ -40,4 +42,13 @@ if scripts_to_install.length() > 0
         install_mode: 'rwxr-xr-x'
     )
 endif
+
+# Install collected include scripts if any
+if include_scripts.length() > 0
+    install_data(include_scripts,
+        install_dir: dreport_include_dir,
+        install_mode: 'rwxr-xr-x'
+    )
+endif
+
 

--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -343,10 +343,10 @@ void SbeDumpCollector::writeDumpFile(
 
     // Construct the filename
     std::ostringstream filenameBuilder;
-    filenameBuilder << std::setw(8) << std::setfill('0') << id
+    filenameBuilder << std::hex << std::setw(8) << std::setfill('0') << id
                     << ".SbeDataClocks"
                     << (clockState == SBE_CLOCK_ON ? "On" : "Off") << ".node"
-                    << static_cast<int>(nodeNum) << "." << chipName
+                    << std::dec << static_cast<int>(nodeNum) << "." << chipName
                     << static_cast<int>(chipPos);
 
     auto dumpPath = path / filenameBuilder.str();

--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -205,7 +205,7 @@ bool SbeDumpCollector::logErrorAndCreatePEL(
 
         // Common FFDC data
         openpower::dump::pel::FFDCData pelAdditionalData = {
-            {"SRC6", std::format("{:X}{:X}", chipPos, (cmdClass | cmdType))}};
+            {"SRC6", std::format("0x{:X}{:X}", chipPos, (cmdClass | cmdType))}};
 
         if (sbeType == SBETypes::OCMB)
         {

--- a/dump/tools/common/include/gendumpheader
+++ b/dump/tools/common/include/gendumpheader
@@ -1,0 +1,549 @@
+#!/bin/bash
+#
+#Header for BMC DUMP
+#This script will create header file only for IBM systems.
+#This script will generate generic IBM dump header format.
+#
+#Note: The dump header will be imposed on the dump file i.e
+#<dump name>.tar.xz/gz only on IBM specific systems, user needs to
+#separate out the header before extracting the dump.
+#
+
+#Constants
+declare -rx DUMP_HEADER_ENTRY_SIZE='516'
+declare -rx SIZE_4='4'
+declare -rx SIZE_8='8'
+declare -rx SIZE_12='12'
+declare -rx SIZE_32='32'
+#Dump Summary size without header
+declare -rx DUMP_SUMMARY_SIZE='1024'
+declare -rx HW_DUMP='00'
+declare -rx HB_DUMP='20'
+declare -rx SBE_DUMP='30'
+declare -rx OP_DUMP="opdump"
+declare -rx INVENTORY_MANAGER='xyz.openbmc_project.Inventory.Manager'
+declare -rx INVENTORY_PATH='/xyz/openbmc_project/inventory/system'
+declare -rx INVENTORY_ASSET_INT='xyz.openbmc_project.Inventory.Decorator.Asset'
+declare -rx INVENTORY_BMC_BOARD='/xyz/openbmc_project/inventory/system/chassis/motherboard'
+declare -rx PHOSPHOR_LOGGING='xyz.openbmc_project.Logging'
+declare -rx PEL_ENTRY='org.open_power.Logging.PEL.Entry'
+declare -rx PEL_ID_PROP='PlatformLogID'
+
+#Variables
+declare -x modelNo
+modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+    $INVENTORY_ASSET_INT Model | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+#Variables
+declare -x serialNo
+serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+    $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+declare -x dDay
+dDay=$(date -d @"$EPOCHTIME" +'%Y%m%d%H%M%S')
+declare -x bmcSerialNo
+bmcSerialNo=$(busctl call $INVENTORY_MANAGER $INVENTORY_BMC_BOARD \
+        org.freedesktop.DBus.Properties Get ss $INVENTORY_ASSET_INT \
+    SerialNumber | cut -d " " -f 3 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+#Function to add NULL
+function add_null() {
+    local a=$1
+    printf '%*s' $a | tr ' ' "\0" >> $FILE
+}
+
+#Function to is to convert the EPOCHTIME collected
+#from dreport into hex values and write the same in
+#header.
+function dump_time() {
+    x=${#dDay}
+    msize=`expr $x / 2`
+    msize=`expr $SIZE_8 - $msize`
+    for ((i=0;i<$x;i+=2));
+    do
+        printf \\x${dDay:$i:2} >> $FILE
+    done
+    add_null $msize
+}
+
+#Function to fetch the size of the dump
+function dump_size() {
+    #Adding 516 bytes as the total dump size is dump tar size
+    #plus the dump header entry in this case
+    #dump_header and dump_entry
+    # shellcheck disable=SC2154 # name_dir comes from elsewhere.
+    dumpSize=$(stat -c %s "$name_dir.bin")
+    sizeDump=$(( dumpSize + DUMP_HEADER_ENTRY_SIZE ))
+    printf -v hex "%x" "$sizeDump"
+    x=${#hex}
+    if [ $(($x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=`expr $x / 2`
+    msize=`expr $SIZE_8 - $msize`
+    add_null $msize
+    for ((i=0;i<$x;i+=2));
+    do
+        printf \\x${hex:$i:2} >> $FILE
+    done
+}
+
+#Function to set dump id to 8 bytes format
+function get_dump_id() {
+    # shellcheck disable=SC2154
+    size=${#dump_id}
+    if [ "$1" == "$OP_DUMP" ]; then
+        nulltoadd=$(( SIZE_4 - size / 2 - size % 2 ))
+        add_null "$nulltoadd"
+        for ((i=0;i<size;i+=2));
+        do
+            # shellcheck disable=SC2059
+            printf "\\x${dump_id:$i:2}" >> "$FILE"
+        done
+    else
+        nulltoadd=$(( SIZE_8 - size ))
+        printf '%*s' "$nulltoadd" | tr ' ' "0" >> "$FILE"
+        printf "%s" "$dump_id" >> "$FILE"
+    fi
+}
+
+#Function to get the bmc serial number
+function getbmc_serial() {
+    x=${#bmcSerialNo}
+    nulltoadd=`expr $SIZE_12 - $x`
+    printf $bmcSerialNo >> $FILE
+    printf '%*s' $nulltoadd | tr ' ' "0" >> $FILE
+}
+
+#Function to fetch the hostname
+function system_name() {
+    name=$(hostname)
+    len=${#name}
+    nulltoadd=$(( SIZE_32 - len ))
+    printf "%s" "$name" >> "$FILE"
+    add_null "$nulltoadd"
+}
+
+#Function to get the errorlog ID
+function get_eid() {
+    # shellcheck disable=SC2154 # dump_type comes from elsewhere
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        # shellcheck disable=SC2154 # elog_id comes from elsewhere
+        x=${#elog_id}
+        if [ "$x" = 8 ]; then
+            msize=$(( x / 2 ))
+            msize=$(( SIZE_4 - msize ))
+            for ((i=0;i<x;i+=2));
+            do
+                printf "\\x${elog_id:$i:2}" >> "$FILE"
+            done
+            add_null "$msize"
+        else
+            add_null 4
+        fi
+    else
+        if ! { [[ $dump_type = "$TYPE_ELOG" ]] || \
+                [[ $dump_type = "$TYPE_CHECKSTOP" ]]; }; then
+            x=${#elog_id}
+            if [ "$x" = 8 ]; then
+                for ((i=0;i<x;i+=2));
+                do
+                    printf "\\x${elog_id:$i:2}" >> "$FILE"
+                done
+            else
+                add_null 4
+            fi
+        else
+            strpelid=$(busctl get-property $PHOSPHOR_LOGGING \
+                $optional_path $PEL_ENTRY $PEL_ID_PROP | cut -d " " -f 2)
+            decpelid=$(expr "$strpelid" + 0)
+            hexpelid=$(printf "%x" "$decpelid")
+            x=${#hexpelid}
+            if [ "$x" = 8 ]; then
+                for ((i=0;i<x;i+=2));
+                do
+                    printf "\\x${hexpelid:$i:2}" >> "$FILE"
+                done
+            else
+                add_null 4
+            fi
+        fi
+    fi
+}
+
+#Function to get the tar size of the dump
+function tar_size() {
+    printf -v hex "%x" "$size_dump"
+    x=${#hex}
+    if [ $((x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=$(( x / 2 ))
+    msize=$(( SIZE_4 - msize ))
+    add_null "$msize"
+    for ((i=0;i<x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'hex' as a variable is safe here.
+        printf "\\x${hex:$i:2}" >> "$FILE"
+    done
+}
+
+#Function will get the total size of the dump without header
+# i.e. Dump summary size i.e. 1024 bytes + the tar file size
+function total_size() {
+    size_dump=$(( size_dump + DUMP_SUMMARY_SIZE ))
+    printf -v hex "%x" "$size_dump"
+    x=${#hex}
+    if [ $((x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=$(( x / 2 ))
+    msize=$(( SIZE_8 - msize ))
+    add_null "$msize"
+    for ((i=0;i<x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'hex' as a variable is safe here.
+        printf "\\x${hex:$i:2}" >> "$FILE"
+    done
+}
+
+#Function to populate content type based on dump type
+function content_type() {
+    type="00000000"
+    # content type:
+    # Hostboot dump = "20"
+    # Hardware dump = "00"
+    # SBE dump = "30"
+    if [ "$dump_content_type" = "$HB_DUMP" ]; then
+        type="00000200"
+    elif [ "$dump_content_type" = "$HW_DUMP" ]; then
+        type="40000000"
+    elif [ "$dump_content_type" = "$SBE_DUMP" ]; then
+        type="02000000"
+    fi
+    x=${#type}
+    for ((i=0;i<$x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'type' as a variable is safe here.
+        printf "\\x${type:$i:2}" >> "$FILE"
+    done
+}
+
+# @brief Fetching model number and serial number property from inventory
+#  If the busctl command fails, populating the model and serial number
+#  with default value i.e. 0
+function get_bmc_model_serial_number() {
+    modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+        $INVENTORY_ASSET_INT Model | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+    if [ -z "$modelNo" ]; then
+        modelNo="00000000"
+    fi
+
+    bmcSerialNo=$(busctl call $INVENTORY_MANAGER $INVENTORY_BMC_BOARD \
+            org.freedesktop.DBus.Properties Get ss $INVENTORY_ASSET_INT \
+        SerialNumber | cut -d " " -f 3 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+    if [ -z "$bmcSerialNo" ]; then
+        bmcSerialNo="000000000000"
+    fi
+}
+
+#Function to add virtual file directory entry, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Entry Header      8            FILE
+#Entry Size        2            0x0040
+#Reserved          10           NULL
+#Entry Type        2            0x0001
+#File Name Prefix  2            0x000F
+#Dump File Type    7            BMCDUMP/SYSDUMP/NAGDUMP
+#Separator         1            .
+#System Serial No  7            System serial number fetched from system
+#Dump Identifier   8            Dump Identifier value fetched from dump
+#Separator         1            .
+#Time stamp        14           Form should be yyyymmddhhmmss
+#Null Terminator   1            0x00
+function dump_file_entry() {
+    printf "FILE    " >> $FILE
+    add_null 1
+    printf '\x40' >> $FILE #Virtual file directory entry size
+    add_null 11
+    printf '\x01' >> $FILE
+    add_null 1
+    printf '\x0F' >> "$FILE"
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        printf "SYSDUMP.%s." "$serialNo" >> "$FILE"
+    else
+        printf "%s.%s." "$header_dump_name" "$serialNo" >> "$FILE"
+    fi
+    get_dump_id
+    printf "." >> $FILE
+    printf $dDay >> $FILE  #UTC time stamp
+    add_null 1
+}
+
+#Function section directory entry, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Entry Header      8            SECTION
+#Entry Size        2            0x0030
+#Section Priority  2            0x0000
+#Reserved          4            NULL
+#Entry Flags       4            0x00000001
+#Entry Types       2            0x0002
+#Reserved          2            NULL
+#Dump Size         8            Dump size in hex + dump header
+#Optional Section  16           BMCDUMP/NAGDUMP/DUMP SUMMARY
+function dump_section_entry() {
+    printf "SECTION " >> $FILE
+    add_null 1
+    printf '\x30' >> "$FILE" #Section entry size
+    add_null 9
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        add_null 1
+    else
+        printf '\x01' >> "$FILE"
+    fi
+    add_null 1
+    printf '\x02' >> "$FILE"
+    add_null 2
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        add_null 6
+        printf '\x04' >> "$FILE"
+        add_null 1
+        printf "DUMP SUMMARY" >> "$FILE"
+        add_null 4
+    else
+        dump_size    #Dump size
+        printf "%s" "$header_dump_name" >> "$FILE"
+        add_null 9
+    fi
+}
+
+#Function to add dump header, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Dump type         8            BMC/NAG DUMP
+#Dump Request time 8            Dump request time stamp (in BCD)
+#Dump Identifier   4            Dump identifer fetched from dump
+#Dump version      2            0x0210
+#Dump header       2            0x200
+#Total dump size   8            Dump size + dump header
+#Panel function    32           System model, feature, type and IPL mode
+#System Name       32           System Name (in ASCII)
+#Serial number     7            System serial number
+#Reserved          1            NULL
+#PLID              4            Comes from errorlog
+#File Header Size  2            0x70
+#Dump SRC Size     2            Dump SRC Size. Currently NULL
+#DUMP SRC          320          DUMP SRC. Currently NULL
+#Dump Req Type     4            Dump requester user interface type.
+#Dump Req ID       32           Dump requester user interface ID
+#Dump Req user ID  32           Dump requester user ID.
+#
+#TODO: Github issue #2639, to populate the unpopulated elements.
+#Note: Unpopulated elements are listed below are set as NULL
+#PLID
+#SRC size
+#SRC dump
+#Dump requestor type
+#Dump Req ID
+#Dump Req user ID
+function dump_header() {
+    if [ $dump_type = "$TYPE_FAULTDATA" ]; then
+        printf "FLT DUMP" >> $FILE
+    else
+        printf "BMC DUMP" >> $FILE
+    fi
+    dump_time
+    add_null 4 #Dump Identifier
+    printf '\x02' >> $FILE #Dump version 0x0210
+    printf '\x10' >> $FILE
+    printf '\x02' >> $FILE #Dump header size 0x0200
+    add_null 1
+    dump_size  #dump size
+    printf "$modelNo" >> "$FILE"
+    add_null 24
+    printf "Server-%s-SN%s" "$modelNo" "$serialNo" >> "$FILE"
+    add_null 7
+    printf "$serialNo" >> "$FILE"
+    add_null 1
+    get_eid
+    add_null 1
+    printf '\x70' >> "$FILE" #File header size
+    add_null 2 # SRC size
+    add_null 320 # SRC dump
+    getbmc_serial
+    add_null 68 # Dump requester details
+}
+
+#Function to add Dump entry, consists of below entries
+####################FORMAT################
+#Name               Size(bytes)  Value
+#Dump Entry Version 1            0x01
+#BMC Dump Valid     1            0x01
+#No of Dump Entry   2            Number of Dump Entry
+#
+function dump_entry() {
+    printf '\x01' >> $FILE #Dump entry version
+    printf '\x01' >> $FILE #Dump valid
+    add_null 1
+    printf '\x10' >> $FILE #Dump entry
+}
+
+#Function to Hardware Dump Section
+####################FORMAT##################
+#Name            Size(bytes)    Value
+#HWDumpHeader      8            SECTION
+#HWDumpEntrySize   2            0x0030
+#HWDumpPriority    2            0x02
+#reserve6          4            NULL
+#HWDumpEntryFlag   4            0x0001
+#HWDumpEntryType   2            0x02
+#reserve7          2            NULL
+#reserve7a         4            NULL
+#HWDumpSize        4            NULL
+#HWDumpName[16]    16           HARDWARE DATA
+function hw_dump_section() {
+    printf "SECTION " >> "$FILE"
+    add_null 1
+    printf '\x30' >> "$FILE" #Section entry size
+    add_null 1
+    printf '\x02' >> "$FILE"
+    add_null 7
+    printf '\x00' >> "$FILE"
+    add_null 1
+    printf '\x02' >> "$FILE"
+    add_null 6
+    tar_size
+    printf "HARDWARE DATA" >> "$FILE"
+    add_null 3
+}
+
+#Function to Mainstore Dump Section
+######################FORMAT###################
+#Name                Size(in bytes)   Value
+#MainstoreHeader         8            SECTION
+#MainstoreEntrySize      2            0x30
+#MainstorePriority       2            0x02
+#reserve8                4            NULL
+#MainstoreEntryFlag      4            NULL
+#MainstoreEntryType      2            0x01
+#reserve9                2            NULL
+#MainstoreSize           8            NULL
+#MainstoreName           16           HYPERVISOR DATA
+function mainstore_dump_section() {
+    printf "SECTION " >> "$FILE"
+    add_null 1
+    printf '\x30' >> "$FILE" #Section entry size
+    add_null 1
+    printf '\x02' >> "$FILE"
+    add_null 7
+    printf '\x01' >> "$FILE"
+    add_null 1
+    printf '\x02' >> "$FILE"
+    add_null 10
+    printf "HYPERVISOR DATA" >> "$FILE"
+    add_null 1
+}
+
+#Function for platform system dump header
+######################FORMAT##################
+#Name                Size(in bytes)   Value
+#eyeCatcher              8            SYS DUMP
+#requestTimestamp        8            BCD time
+#dumpIdentifier          4
+#dumpVersion             2
+#headerSize              2
+#totalDumpSize           8
+#machineInfo             32
+#systemName              32
+#systemSerialNumber      7
+#Dump Creator BMC        1
+#eventLogId              4
+#fileHeaderSize          2
+####################DATA NOT AVAIABLE##########
+#srcSize                 2
+#dumpSrc                 332
+#toolType                4
+#clientId                32
+#userId                  32
+#systemDumpFlags         2
+#hardwareErrorFlags      2
+#processorChipEcid       2
+#hardwareObjectModel     1
+#chUnused                1
+#cecMemoryErrorFlags     8
+#memoryDumpStartTime     8
+#memoryDumpCompleteTime  8
+#hypVerRelMod            8
+#Reserved4HysrInfo       2
+#hypMode                 1
+#hypDumpContentPolicy    1
+#Reserved4HWDInfo        2
+#hardwareNodalCount      2
+#hardwareDumpTableSize   4
+#hardwareDumpDataSize    4
+#totalHardwareDumpDataSize   4
+#mdrtTableSize           4
+#mdrtTableAddress        8
+#memoryDumpDataSize      8
+#hypModLoadMapTime       8
+#hardwareCollectionEndTime   8
+#contentType             4
+#failingUnitId           4
+#failingCappChipId       2
+#failingCappUnitId       1
+#reserve02               5
+#hypHRMOR                8
+#hypNACAAddress          8
+#hardwareCollectionStartTime  8
+#mdstTableSize           4
+#payloadState            4
+#creator BMC             1
+#reservedForCreator      169
+function plat_dump_header() {
+    printf "SYS DUMP" >> "$FILE"
+    dump_time
+    get_dump_id "$OP_DUMP"   #Dump identifier
+    printf '\x02' >> "$FILE"
+    printf '\x21' >> "$FILE" #Need to cross check
+    printf '\x04' >> "$FILE" #Dump header size 0x0400
+    add_null 1
+    total_size
+    printf "%s" "$modelNo" >> "$FILE"
+    add_null 24
+    system_name
+    printf "%s" "$serialNo" >> "$FILE"
+    printf '\x01' >> "$FILE"   #Dump Creator BMC
+    get_eid
+    add_null 1
+    printf '\xd0' >> "$FILE" #File Header size
+    add_null 498
+    content_type # 4 bytes
+    add_null 44
+    printf '\x01' >> "$FILE"  # BMC indicator
+    add_null 367
+}
+
+
+#main function
+function gen_header_package() {
+    dump_file_entry
+    dump_section_entry
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        hw_dump_section
+        mainstore_dump_section
+        plat_dump_header
+    else
+        dump_header
+        dump_entry
+    fi
+}
+
+get_bmc_model_serial_number
+
+#Run gen_header_package
+gen_header_package

--- a/dump/tools/common/include/gendumpinfo
+++ b/dump/tools/common/include/gendumpinfo
@@ -1,0 +1,73 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+
+# Constants
+declare -rx DUMP_MANAGER='xyz.openbmc_project.Dump.Manager'
+declare -rx DUMP_PATH='/xyz/openbmc_project/dump/system/entry'
+declare -rx DUMP_PROP='xyz.openbmc_project.Common.Progress'
+
+# Variables
+declare -x DRIVER=""
+declare -x YAML_FILE=""
+declare -x ADDL_DATA_PATH=""
+declare -x START_TIME=0
+declare -x END_TIME=0
+
+# Initialize variables
+function initialize_variables() {
+    DRIVER=$(awk -F '[=()]' '/VERSION_ID/ {print $2}' /etc/os-release)
+    YAML_FILE="$content_path/info.yaml"
+    ADDL_DATA_PATH="$content_path/plat_dump/additional_data/"
+}
+
+# Function to get the dump start and completed time
+function dump_time_details() {
+    START_TIME=$(busctl get-property "$DUMP_MANAGER" "$DUMP_PATH/$dump_id" \
+        "$DUMP_PROP" StartTime | awk '{print $2}')
+    END_TIME=$(busctl get-property "$DUMP_MANAGER" "$DUMP_PATH/$dump_id" \
+        "$DUMP_PROP" CompletedTime | awk '{print $2}')
+
+    if [ -z "$START_TIME" ] || [ "$START_TIME" -eq 0 ]; then
+        echo "Could not fetch start time for $dump_id. Setting manually"
+        START_TIME=$(date +%s)
+    fi
+
+    start=$(date -d @"$START_TIME" +'%Y-%m-%d %H:%M:%S')
+    if [ -z "$END_TIME" ] || [ "$END_TIME" -eq 0 ]; then
+        echo "Could not fetch end time for $dump_id. Setting manually"
+        END_TIME=$(date +%s)
+    fi
+    end=$(date -d @"$END_TIME" +'%Y-%m-%d %H:%M:%S')
+
+    printf "dump-start-time: %s\n" "$start" >> "$YAML_FILE"
+    printf "dump-end-time: %s\n" "$end" >> "$YAML_FILE"
+}
+
+# Function to fetch additional details
+function get_addl_data() {
+    if [ -d "$ADDL_DATA_PATH" ]; then
+        for entry in "$ADDL_DATA_PATH"/*; do
+            while IFS= read -r line; do
+                echo "$line" >> "$YAML_FILE"
+            done < "$entry"
+        done
+    fi
+}
+
+# Function to write data to info.yaml file
+function write_to_info_file() {
+    {
+        printf "%s\n" "# SPDX-License-Identifier: GPL-2.0"
+        printf "%s\n" "%YAML 1.2"
+        printf "%s\n\n" "---"
+        printf "generation: p10\n"
+        printf "driver: %s\n" "$DRIVER"
+    } >> "$YAML_FILE"
+    dump_time_details
+    get_addl_data
+}
+
+# Run main
+initialize_variables
+write_to_info_file
+

--- a/dump/tools/common/include/meson.build
+++ b/dump/tools/common/include/meson.build
@@ -1,0 +1,1 @@
+include_scripts += meson.current_source_dir() / 'gendumpheader'

--- a/dump/tools/common/include/meson.build
+++ b/dump/tools/common/include/meson.build
@@ -1,1 +1,2 @@
 include_scripts += meson.current_source_dir() / 'gendumpheader'
+include_scripts += meson.current_source_dir() / 'gendumpinfo'

--- a/dump/tools/common/meson.build
+++ b/dump/tools/common/meson.build
@@ -1,0 +1,1 @@
+subdir('include')

--- a/dump/tools/meson.build
+++ b/dump/tools/meson.build
@@ -1,1 +1,2 @@
 subdir('opdump')
+subdir('common')

--- a/dump/tools/meson.build
+++ b/dump/tools/meson.build
@@ -1,0 +1,1 @@
+subdir('opdump')

--- a/dump/tools/opdump/meson.build
+++ b/dump/tools/opdump/meson.build
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+scripts_to_install += meson.current_source_dir() / 'opdreport'

--- a/dump/tools/opdump/opdreport
+++ b/dump/tools/opdump/opdreport
@@ -1,0 +1,264 @@
+#!/bin/bash
+# shellcheck disable=SC2034  # Variable is used elsewhere
+
+help=$(cat << EOF
+        opdreport creates an archive consisting of the following:
+                * host dump files and header applied on top of it
+        The type parameter controls the content of the data. The generated
+        archive is stored in the user specified location.
+
+usage: opdreport [OPTION]
+
+Options:
+        -n, --name <name>     Name to be used for the archive.
+                              Default name format
+                              SYSDUMP.<serial number>.<dump_id>.<time>
+                              Optional parameter.
+        -d, --dir <directory> Archive directory to copy the compressed report.
+                              Default output directory is current working
+                              directory. Optional parameter.
+        -i, --dumpid <id>     Dump identifier to associate with the archive.
+                              Identifiers include numeric characters.
+                              Default dump identifier is 0
+        -s, --size <size>     Maximum allowed size (in KB) of the archive.
+                              Report will be truncated if size exceeds
+                              this limit. Default size is unlimited.
+        -f, --failingunit     The id of the failed unit
+        -e, --eid             Error log associated with the failure
+        -t, --type            Type of the dump to be collected
+                              1  -  Hardware dump
+                              3  -  Performance dump
+                              5  -  Hostboot dump
+                              10 -  SBE Dump
+        -h, --help            Display this help and exit.
+EOF
+)
+
+# Constants
+readonly OP_DUMP="opdump"
+readonly DREPORT_SOURCE="/usr/share/dreport.d"
+readonly TRUE=1
+readonly FALSE=0
+readonly TIME_STAMP="date -u"
+readonly UNLIMITED="unlimited"
+readonly DREPORT_INCLUDE="$DREPORT_SOURCE/include.d"
+readonly INVENTORY_MANAGER='xyz.openbmc_project.Inventory.Manager'
+readonly INVENTORY_PATH='/xyz/openbmc_project/inventory/system'
+readonly INVENTORY_ASSET_INT='xyz.openbmc_project.Inventory.Decorator.Asset'
+readonly INVENTORY_BMC_BOARD='/xyz/openbmc_project/inventory/system/chassis/motherboard'
+readonly HEADER_EXTENSION="$DREPORT_INCLUDE/gendumpheader"
+readonly FILE_SCRIPT="$DREPORT_SOURCE/include.d/gendumpinfo"
+
+# Error Codes
+readonly SUCCESS=0
+readonly INTERNAL_FAILURE=1
+readonly RESOURCE_UNAVAILABLE=2
+
+# Variables
+declare -x dump_type="$OP_DUMP"
+declare -x dump_sbe_type=100
+declare -x size_dump=""
+declare -x elog_id="00000000"
+declare -x EPOCHTIME
+EPOCHTIME=$(date +"%s")
+declare -x name=""
+declare -x dump_dir="/tmp"
+declare -x dump_id="00000000"
+declare -x dump_size="unlimited"
+declare -x content_path=""
+declare -x name_dir=""
+declare -x serialNo="0000000"
+declare -x dDay
+dDay=$(date -d @"$EPOCHTIME" +'%Y%m%d%H%M%S')
+declare -x dump_content_type=""
+declare -x FILE=""
+
+# @brief Get serial number property from inventory
+function fetch_serial_number() {
+    serialNo=$(busctl get-property "$INVENTORY_MANAGER" "$INVENTORY_PATH" \
+            "$INVENTORY_ASSET_INT" SerialNumber | cut -d " " -f 2 | \
+        sed 's/^"\(.*\)"$/\1/')
+
+    if [ -z "$serialNo" ]; then
+        serialNo="0000000"
+    fi
+}
+
+# @brief Check the validity of user inputs and initialize global variables
+function initialize() {
+    # shellcheck disable=SC2154 # name comes from elsewhere
+    if [ -z "$name" ]; then
+        name="SYSDUMP"
+    fi
+    fetch_serial_number
+    # shellcheck disable=SC2154 # dump_id comes from elsewhere
+    name="${name}.${serialNo}.${dump_id}.${dDay}"
+
+    if [ -z "$dump_sbe_type" ]; then
+        echo "Error: Dump type is not provided."
+        return "$RESOURCE_UNAVAILABLE"
+    fi
+
+    if [ -z "$dump_dir" ]; then
+        dump_dir=$PWD
+    fi
+
+    if [[ "$dump_size" =~ ^[0-9]+$ ]]; then
+        dump_size=$((dump_size * 1024))
+    else
+        dump_size=$UNLIMITED
+    fi
+
+    return "$SUCCESS"
+}
+
+# @brief Collect the dump
+function collect() {
+    content_path="/tmp/dump_${dump_id}_${EPOCHTIME}"
+    dump_outpath="$content_path/plat_dump"
+    if ! mkdir -p "$dump_outpath"; then
+        echo "Could not create the destination directory $dump_outpath"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    dump-collect --type "$dump_sbe_type" --id "0x$dump_id" \
+        --failingunit "$failing_unit" --path "$dump_outpath"
+}
+
+# @brief Package the dump and transfer to dump location
+function package() {
+    FILE="/tmp/dumpheader_${dump_id}_${EPOCHTIME}"
+    if ! mkdir -p "$dump_dir"; then
+        echo "Could not create the destination directory $dump_dir"
+        dump_dir="/tmp"
+    fi
+
+    cd "$content_path" || exit "$INTERNAL_FAILURE"
+
+    dump_content_type=${id:0:2}
+    "$FILE_SCRIPT"
+    elog_id=$eid
+
+    if ! tar -cvzf "$name" plat_dump/*Sbe* info.yaml; then
+        echo "$($TIME_STAMP)" "Could not create the compressed tar file"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    size_dump=$(stat -c %s "$name")
+
+    if [ "$dump_size" != "$UNLIMITED" ] && \
+        [ "$size_dump" -gt "$dump_size" ]; then
+        rm "$name"
+        return "$RESOURCE_UNAVAILABLE"
+    fi
+
+    echo "Adding Dump Header: $HEADER_EXTENSION"
+    "$HEADER_EXTENSION"
+
+    if ! tee -a "$FILE" < "$name" > /dev/null; then
+        echo "$($TIME_STAMP)" "Could not create the compressed file"
+        rm -rf "$name" "$FILE"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    if ! mv "$FILE" "$name"; then
+        echo "$($TIME_STAMP)" "Could not create the compressed file"
+        rm -rf "$name" "$FILE"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    mv "$name" "$dump_dir"
+
+    rm -rf "$content_path"
+    rm -rf "$FILE" "$name"
+
+    return "$SUCCESS"
+}
+
+# @brief Initiate BMC dump
+function initiate_bmc_dump() {
+    bmcDumpPath=$(busctl call xyz.openbmc_project.Dump.Manager \
+            /xyz/openbmc_project/dump/bmc \
+        xyz.openbmc_project.Dump.Create CreateDump a\{sv\} 0)
+    result=$?
+    if [[ $result -ne $SUCCESS ]]; then
+        echo "Error in creating BMC dump associated with system dump"
+    else
+        echo "BMC dump initiated $bmcDumpPath"
+    fi
+}
+
+# @brief Main function
+function main() {
+    initialize
+    result=$?
+    if [[ $result -ne $SUCCESS ]]; then
+        echo "$($TIME_STAMP)" "Error: Failed to initialize, Exiting"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    collect
+    result=$?
+    if [[ $result -ne $SUCCESS ]]; then
+        echo "$($TIME_STAMP)" "Error: Failed to collect dump, Exiting"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    package
+    result=$?
+    if [[ $result -ne $SUCCESS ]]; then
+        echo "$($TIME_STAMP)" "Error: Failed to package, Exiting"
+        return "$INTERNAL_FAILURE"
+    else
+        echo "$($TIME_STAMP)" "Successfully completed"
+    fi
+
+    initiate_bmc_dump
+    return "$SUCCESS"
+}
+
+if ! TEMP=$(getopt -o n:d:i:s:t:e:f:h \
+        --long name:,dir:,dumpid:,size:,type:,eid:,failingunit:,help \
+        -- "$@"); then
+    echo "Error: Invalid options"
+    exit 1
+fi
+
+eval set -- "$TEMP"
+
+while [[ $# -gt 1 ]]; do
+    key="$1"
+    case $key in
+        -n|--name)
+            name=$2
+            shift 2 ;;
+        -d|--dir)
+            dump_dir=$2
+            shift 2 ;;
+        -i|--dumpid)
+            dump_id=$2
+            shift 2 ;;
+        -s|--size)
+            dump_size=$2
+            shift 2 ;;
+        -f|--failingunit)
+            failing_unit=$2
+            shift 2 ;;
+        -e|--eid)
+            eid=$2
+            shift 2 ;;
+        -t|--type)
+            dump_sbe_type=$2
+            shift 2 ;;
+        -h|--help)
+            echo "$help"
+            exit ;;
+        *) # unknown option
+            echo "Unknown argument: $1"
+            echo "$help"
+            exit 1 ;;
+    esac
+done
+
+main
+exit $?

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ endif
 
 configure_file(output: 'config.h', configuration: conf_data)
 
-if get_option('dump-collection').enabled()
+if get_option('dump-collection').allowed()
      subdir('dump')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ endif
 configure_file(output: 'config.h', configuration: conf_data)
 
 if get_option('dump-collection').enabled()
-    subdir('dump')
+     subdir('dump')
 endif
 
 deps = [


### PR DESCRIPTION
71527: Create Dump Header for IBM Systems | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71527

71513: Add opdreport tool to OpenPOWER Debug Collector | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71513

71514: Add script to generate dump info file | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71514

71528: Dump id needs to be hex dump files | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71528

71531: Add '0x' Prefix to Indicate Hexadecimal Values | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71531

71515: Add Dump Monitoring Support | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71515

71640: Add support for system dump | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71640

71516: Add systemd service for OpenPOWER Dump Monitor | https://gerrit.openbmc.org/c/openbmc/openpower-debug-collector/+/71516