### PR TITLE
Log PEL as informational during dump path

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -166,8 +166,9 @@ void collectDumpFromSBE(struct pdbg_target* proc,
         pelAdditionalData.emplace_back("SRC6",
                                        std::to_string((chipPos << 16) | cmd));
 
-        auto logId = openpower::dump::pel::createSbeErrorPEL(event, sbeError,
-                                                             pelAdditionalData);
+        auto logId = openpower::dump::pel::createSbeErrorPEL(
+            event, sbeError, pelAdditionalData,
+            openpower::dump::pel::Severity::Informational);
 
         if (dumpIsRequired)
         {


### PR DESCRIPTION
Log PELs as informational during dumping path since system is already in bad state and any errors while collecting dump can be due to the side effect of original failure.