### PR TITLE
Move clear host dump service to openpower-debug-collector

### DIFF
--- a/dump/dist/clear_resourcedumps_poweroff.service
+++ b/dump/dist/clear_resourcedumps_poweroff.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Remove resource dump entries during poweroff
+Wants=obmc-host-stop-pre@0.target
+After=obmc-host-stop-pre@0.target
+Wants=obmc-host-stopping@0.target
+Before=obmc-host-stopping@0.target
+Conflicts=obmc-host-startmin@0.target
+ConditionPathExists=!/run/openbmc/host@0-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/dumpdelete com.ibm.Dump.Entry.Resource
+
+RemainAfterExit=yes
+
+[Install]
+#WantedBy=obmc-host-stop@0.target
+

--- a/dump/dist/clear_systemdumps_poweroff.service
+++ b/dump/dist/clear_systemdumps_poweroff.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Remove system dump entries during poweroff
+Wants=obmc-host-stop-pre@0.target
+After=obmc-host-stop-pre@0.target
+Wants=obmc-host-stopping@0.target
+Before=obmc-host-stopping@0.target
+After=op-enter-mpreboot@0.service
+Conflicts=obmc-host-startmin@0.target
+ConditionPathExists=!/run/openbmc/host@0-on
+ConditionPathExists=!/run/openbmc/mpreboot@0
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/dumpdelete xyz.openbmc_project.Dump.Entry.System
+
+RemainAfterExit=yes
+
+[Install]
+#WantedBy=obmc-host-stop@0.target
+

--- a/dump/dist/meson.build
+++ b/dump/dist/meson.build
@@ -17,10 +17,36 @@ configure_file(
   install_dir: systemd_system_unit_dir
 )
 
+configure_file(
+  input: 'clear_systemdumps_poweroff.service',
+  output: 'clear_systemdumps_poweroff.service',
+  configuration: dist_conf_data,
+  install: true,
+  install_dir: systemd_system_unit_dir
+)
+
+configure_file(
+  input: 'clear_resourcedumps_poweroff.service',
+  output: 'clear_resourcedumps_poweroff.service',
+  configuration: dist_conf_data,
+  install: true,
+  install_dir: systemd_system_unit_dir
+)
+
 # Symlinks for services
 systemd_alias = [
     ['../openpower-dump-monitor.service',
      'obmc-host-startmin@0.target.wants/openpower-dump-monitor.service']
+]
+
+systemd_alias += [
+    ['../clear_systemdumps_poweroff.service',
+     'obmc-host-stop@0.target.wants/clear_systemdumps_poweroff.service']
+]
+
+systemd_alias += [
+    ['../clear_resourcedumps_poweroff.service',
+     'obmc-host-stop@0.target.wants/clear_resourcedumps_poweroff.service']
 ]
 
 foreach service: systemd_alias

--- a/dump/tools/opdump/dumpdelete
+++ b/dump/tools/opdump/dumpdelete
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if the interface parameter is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <interface>"
+    echo "Example: $0 xyz.openbmc_project.Dump.Entry.BMC"
+    exit 1
+fi
+
+INTERFACE=$1
+
+# Run the busctl command with verbose output and capture the output
+output=$(busctl --verbose call xyz.openbmc_project.Dump.Manager \
+        /xyz/openbmc_project/dump \
+        org.freedesktop.DBus.ObjectManager \
+    GetManagedObjects)
+
+# Parse the output and print object paths containing the specified interface
+declare -A seen_paths
+
+echo "$output" | awk -v interface="$INTERFACE" '
+  /OBJECT_PATH/ {
+    path = $2;
+    gsub(/;/, "", path);
+    gsub(/"/, "", path);
+  }
+  $0 ~ interface {
+    print path;
+  }
+' | while read -r path; do
+    if [ -z "${seen_paths[$path]}" ]; then
+        echo "Deleting: $path"
+        busctl call xyz.openbmc_project.Dump.Manager "${path}" \
+            xyz.openbmc_project.Object.Delete Delete
+        seen_paths["$path"]=1
+    fi
+done

--- a/dump/tools/opdump/meson.build
+++ b/dump/tools/opdump/meson.build
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 scripts_to_install_bindir += meson.current_source_dir() / 'opdreport'
+scripts_to_install_bindir += meson.current_source_dir() / 'dumpdelete'


### PR DESCRIPTION
Move the clear_hostdumps_poweroff.service to openpower-debug-collector as it is needed only on IBM systems. Additionally added the scripts to selectively delete all entries based on the dump interface to delete only resource dump and system dump during power off.

Each type of dump will have separate service files due to difference in activation, system dump entries are not cleared during an mpreboot

Change-Id: Ibf20b097862acb3dc7887cd75d4d5ba6bc1ff5c3