### PR TITLE
 Log PEL as informational during dump path

### DIFF
--- a/dump/create_pel.cpp
+++ b/dump/create_pel.cpp
@@ -35,7 +35,7 @@ constexpr auto loggingInterface = "xyz.openbmc_project.Logging.Create";
 constexpr auto opLoggingInterface = "org.open_power.Logging.PEL";
 
 uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
-                           const FFDCData& ffdcData)
+                           const FFDCData& ffdcData, const Severity severity)
 {
     uint32_t plid = 0;
     std::map<std::string, std::string> additionalData;
@@ -80,8 +80,7 @@ uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
                                 opLoggingInterface, "CreatePELWithFFDCFiles");
         auto level =
             sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
-                sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level::
-                    Error);
+                severity);
         method.append(event, level, additionalData, pelFFDCInfo);
         auto response = bus.call(method);
 

--- a/dump/create_pel.hpp
+++ b/dump/create_pel.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "xyz/openbmc_project/Logging/Entry/server.hpp"
+
 #include <phal_exception.H>
 
 #include <nlohmann/json.hpp>
@@ -14,6 +16,8 @@ namespace pel
 {
 using FFDCData = std::vector<std::pair<std::string, std::string>>;
 
+using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+
 using json = nlohmann::json;
 
 using namespace openpower::phal;
@@ -24,10 +28,12 @@ using namespace openpower::phal;
  * @param[in] event - the event type
  * @param[in] sbeError - SBE error object
  * @param[in] ffdcData - failure data to append to PEL
+ * @param[in] severity - severity of the log
  * @return Platform log id
  */
 uint32_t createSbeErrorPEL(const std::string& event, const sbeError_t& sbeError,
-                           const FFDCData& ffdcData);
+                           const FFDCData& ffdcData,
+                           const Severity severity = Severity::Error);
 
 /**
  * @class FFDCFile

--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -109,10 +109,9 @@ void collectDumpFromSBE(struct pdbg_target* proc,
         uint32_t cmd = SBE::SBEFIFO_CMD_CLASS_DUMP | SBE::SBEFIFO_CMD_GET_DUMP;
         pelAdditionalData.emplace_back("SRC6",
                                        std::to_string((chipPos << 16) | cmd));
-        openpower::dump::pel::createSbeErrorPEL(event, sbeError,
-                                                pelAdditionalData);
-        auto logId = openpower::dump::pel::createSbeErrorPEL(event, sbeError,
-                                                             pelAdditionalData);
+        auto logId = openpower::dump::pel::createSbeErrorPEL(
+            event, sbeError, pelAdditionalData,
+            openpower::dump::pel::Severity::Informational);
 
         if (dumpIsRequired)
         {

--- a/dump/dump_collect_main.cpp
+++ b/dump/dump_collect_main.cpp
@@ -2,6 +2,8 @@
 #include "dump_collect.hpp"
 #include "sbe_consts.hpp"
 
+#include <libphal.H>
+
 #include <iostream>
 #include <string>
 
@@ -27,7 +29,8 @@ int main(int argc, char** argv)
 
     auto type = std::stoi(typeStr);
     if (!((type == openpower::dump::SBE::SBE_DUMP_TYPE_HOSTBOOT) ||
-          (type == openpower::dump::SBE::SBE_DUMP_TYPE_HARDWARE)))
+          (type == openpower::dump::SBE::SBE_DUMP_TYPE_HARDWARE) ||
+          (type == openpower::dump::SBE::SBE_DUMP_TYPE_SBE)))
     {
         ExitWithError("type specified is invalid.", argv);
     }
@@ -49,7 +52,15 @@ int main(int argc, char** argv)
     auto failingUnit = std::stoi(failingUnitStr);
     try
     {
-        openpower::dump::sbe_chipop::collectDump(type, id, failingUnit, path);
+        if (type == openpower::dump::SBE::SBE_DUMP_TYPE_SBE)
+        {
+            openpower::phal::dump::collectSBEDump(id, failingUnit, path);
+        }
+        else
+        {
+            openpower::dump::sbe_chipop::collectDump(type, id, failingUnit,
+                                                     path);
+        }
     }
     catch (const std::exception& e)
     {

--- a/dump/dump_manager.cpp
+++ b/dump/dump_manager.cpp
@@ -343,36 +343,13 @@ sdbusplus::message::object_path
         dumpPath /= OP_SBE_FILES_PATH;
 
         util::prepareCollection(dumpPath, elogId);
-        if ((type == SBE::SBE_DUMP_TYPE_HARDWARE) ||
-            (type == SBE::SBE_DUMP_TYPE_HOSTBOOT))
-        {
-            execl("/usr/bin/dump-collect", "dump-collect", "--type",
-                  std::to_string(type).c_str(), "--id",
-                  std::to_string(id).c_str(), "--path", dumpPath.c_str(),
-                  "--failingunit", std::to_string(failingUnit).c_str(),
-                  (char*)0);
-            log<level::ERR>(
-                fmt::format("Failed to start collection error({})", errno)
-                    .c_str());
-            std::exit(EXIT_FAILURE);
-        }
-        else if ((type == SBE::SBE_DUMP_TYPE_SBE))
-        {
-            try
-            {
-                openpower::phal::dump::collectSBEDump(id, failingUnit,
-                                                      dumpPath);
-            }
-            catch (const std::exception& e)
-            {
-                log<level::ERR>(
-                    fmt::format("Failed to collect SBE dump error({})",
-                                e.what())
-                        .c_str());
-                std::exit(EXIT_FAILURE);
-            }
-        }
-        std::exit(EXIT_SUCCESS);
+        execl("/usr/bin/dump-collect", "dump-collect", "--type",
+              std::to_string(type).c_str(), "--id", std::to_string(id).c_str(),
+              "--path", dumpPath.c_str(), "--failingunit",
+              std::to_string(failingUnit).c_str(), (char*)0);
+        log<level::ERR>(
+            fmt::format("Failed to start collection error({})", errno).c_str());
+        std::exit(EXIT_FAILURE);
     }
     else if (pid < 0)
     {

--- a/watchdog/watchdog_main.cpp
+++ b/watchdog/watchdog_main.cpp
@@ -138,15 +138,21 @@ void handleSbeBootError(struct pdbg_target* procTarget, const uint32_t timeout)
     std::unique_ptr<FFDCFile> ffdcFilePtr;
     try
     {
-        json jsonCalloutDataList;
-        jsonCalloutDataList = json::array();
-        getSBECallout(procTarget, jsonCalloutDataList);
-        ffdcFilePtr = std::make_unique<FFDCFile>(jsonCalloutDataList);
-        ffdc.push_back(std::make_tuple(
-            sdbusplus::xyz::openbmc_project::Logging::server::Create::
-                FFDCFormat::JSON,
-            static_cast<uint8_t>(0xCA), static_cast<uint8_t>(0x01),
-            ffdcFilePtr->getFileDescriptor()));
+        if (dumpIsRequired)
+        {
+            // Additional callout is required for SBE timeout case
+            // In this case no SBE FFDC information available and
+            // required to add default callouts.
+            json jsonCalloutDataList;
+            jsonCalloutDataList = json::array();
+            getSBECallout(procTarget, jsonCalloutDataList);
+            ffdcFilePtr = std::make_unique<FFDCFile>(jsonCalloutDataList);
+            ffdc.push_back(std::make_tuple(
+                sdbusplus::xyz::openbmc_project::Logging::server::Create::
+                    FFDCFormat::JSON,
+                static_cast<uint8_t>(0xCA), static_cast<uint8_t>(0x01),
+                ffdcFilePtr->getFileDescriptor()));
+        }
     }
     catch (const std::exception& e)
     {

--- a/watchdog/watchdog_main.hpp
+++ b/watchdog/watchdog_main.hpp
@@ -26,5 +26,13 @@ void triggerHostbootDump(const uint32_t timeout);
  */
 void handleSbeBootError(struct pdbg_target* procTarget, const uint32_t timeout);
 
+/**
+ * @brief creates a PEL and triggers System dump
+ *
+ * @details This function creates the PEL and then triggers System dump
+ *
+ */
+void triggerSystemDump();
+
 } // namespace dump
 } // namespace watchdog

--- a/watchdog_timeout.cpp
+++ b/watchdog_timeout.cpp
@@ -64,9 +64,22 @@ int main(int argc, char* argv[])
                 return EXIT_SUCCESS;
             }
 
-            // SBE boot done, Need to collect hostboot dump
-            log<level::INFO>("Handle Hostboot boot failure");
-            triggerHostbootDump(timeout);
+            // If the hostboot has transitioned to host, and there is a failure
+            // before host is loaded we will hit the below piece of code,
+            // so trigger system dump
+            if (openpower::phal::pdbg::hasControlTransitionedToHost())
+            {
+                // hostboot done, Need to collect system dump
+                log<level::INFO>(
+                    "Failure while booting host, triggering system dump");
+                triggerSystemDump();
+            }
+            else
+            {
+                // SBE boot done, Need to collect hostboot dump
+                log<level::INFO>("Handle Hostboot boot failure");
+                triggerHostbootDump(timeout);
+            }
         }
         else
         {


### PR DESCRIPTION
Log PELs as informational during dumping path since system is
already in bad state and any errors while collecting dump can
be due to the side effect of original failure.