### PR TITLE
Log PEL as informational during dump path

### DIFF
--- a/dump/dump_collect.cpp
+++ b/dump/dump_collect.cpp
@@ -109,10 +109,9 @@ void collectDumpFromSBE(struct pdbg_target* proc,
         uint32_t cmd = SBE::SBEFIFO_CMD_CLASS_DUMP | SBE::SBEFIFO_CMD_GET_DUMP;
         pelAdditionalData.emplace_back("SRC6",
                                        std::to_string((chipPos << 16) | cmd));
-        openpower::dump::pel::createSbeErrorPEL(event, sbeError,
-                                                pelAdditionalData);
-        auto logId = openpower::dump::pel::createSbeErrorPEL(event, sbeError,
-                                                             pelAdditionalData);
+        auto logId = openpower::dump::pel::createSbeErrorPEL(
+            event, sbeError, pelAdditionalData,
+            openpower::dump::pel::Severity::Informational);
 
         if (dumpIsRequired)
         {


### PR DESCRIPTION
Log PELs as informational during dumping path since system is already in bad state and any errors while collecting dump can be due to the side effect of original failure.