### PR TITLE
package: Support customized dump naming

### DIFF
--- a/dump/tools/bmcdump/scripts/package
+++ b/dump/tools/bmcdump/scripts/package
@@ -1,9 +1,20 @@
 #!/bin/bash
 
+#CONSTANTS
+declare -rx HEADER_EXTENSION="$DREPORT_INCLUDE/gendumpheader"
+
+#Source opfunctions
+. $DREPORT_INCLUDE/opfunctions
+
 # @brief Packaging the dump, applying the header
 # and transferring to dump location.
 function custom_package()
 {
+    #fetch customized dump name and rename
+    get_bmc_dump_filename
+    mv "$name_dir" "$TMP_DIR/$name"
+    name_dir="$TMP_DIR/$name"
+
     FILE="/tmp/dumpheader_${dump_id}_${EPOCHTIME}"
     echo "performing dump compression $name_dir"
     if [ "$dump_type" = "$TYPE_FAULTDATA" ]; then


### PR DESCRIPTION
Customize a dump name by renaming the original
default name.

Tested:
Verified that BMC Dump is getting generated
and renamed as follows.
BMCDUMP.<serialNo>.<dump_id>.<dDay>

Change-Id: I5d51693495ef4bf3fc0eff04c03b11cb9e4c225b