### PR TITLE
gendumpheader: Originator details info added

### DIFF
--- a/dump/tools/bmcdump/scripts/package
+++ b/dump/tools/bmcdump/scripts/package
@@ -31,6 +31,8 @@ function custom_package()
         return "$INTERNAL_FAILURE"
     fi
 
+    get_originator_details
+
     echo "Adding Dump Header :"$HEADER_EXTENSION
     ("$HEADER_EXTENSION")
 

--- a/dump/tools/common/include/gendumpheader
+++ b/dump/tools/common/include/gendumpheader
@@ -50,6 +50,31 @@ function add_null() {
     printf '%*s' $a | tr ' ' "\0" >> $FILE
 }
 
+# Function to add Originator details to dump header
+function add_originator_details() {
+    if [ -z "$ORIGINATOR_TYPE" ]; then
+        add_null 4
+        return
+    fi
+    len=${#ORIGINATOR_TYPE}
+    nulltoadd=$(( SIZE_4 - len ))
+    printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
+    if [ "$nulltoadd" -gt 0 ]; then
+        add_null "$nulltoadd"
+    fi
+
+    if [ -z "$ORIGINATOR_ID" ]; then
+        add_null 32
+        return
+    fi
+    len=${#ORIGINATOR_ID}
+    nulltoadd=$(( SIZE_32 - len ))
+    printf '%s' "$ORIGINATOR_ID" >> "$FILE"
+    if [ "$nulltoadd" -gt 0 ]; then
+        add_null "$nulltoadd"
+    fi
+}
+
 #Function to is to convert the EPOCHTIME collected
 #from dreport into hex values and write the same in
 #header.
@@ -376,7 +401,9 @@ function dump_header() {
     add_null 2 # SRC size
     add_null 320 # SRC dump
     getbmc_serial
-    add_null 68 # Dump requester details
+    # Dump requester/Originator details
+    add_originator_details
+    add_null 32 # Dump Req user ID
 }
 
 #Function to add Dump entry, consists of below entries

--- a/dump/tools/common/include/opfunctions
+++ b/dump/tools/common/include/opfunctions
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+#Dump originator variables
+declare -x ORIGINATOR_TYPE=""
+declare -x ORIGINATOR_ID=""
+
 # @brief fetch serial number
 # @param serial number
 function fetch_serial_number() {
@@ -25,3 +29,92 @@ function get_bmc_dump_filename() {
         name="BMCDUMP.${serialNo}.${dump_id}.${dDay}"
     fi
 }
+
+# @brief Function to get the Originator details
+# @param Originator Type and Originator ID
+function get_originator_details() {
+    if [ -z "$dump_dir" ]; then
+        return
+    fi
+
+    # A hash map for each possible dump types
+    # Add/Remove as per the requirement
+    local -A dump_name_map
+    dump_name_map["faultlogs"]="faultlog"
+    dump_name_map["opdump"]="system"
+    dump_name_map["user"]="bmc"
+    dump_name_map["elog"]="bmc"
+    dump_name_map["dumps"]="bmc"
+
+    dump_type_received="$dump_type"
+    dump_entry_id="$dump_id"
+    dump_type_mapped=""
+
+    for key in "${!dump_name_map[@]}"
+    do
+        if [ "$key" = "$dump_type_received" ]; then
+            dump_type_mapped="${dump_name_map[$key]}"
+            break
+        fi
+    done
+
+    # If the dump type received is not in the known list/map
+    # then return then and there to avoid the dbus call which
+    # would be definitely failed due to wrong object path string
+    # made by the line at LN75
+    if [ -z "$dump_type_mapped" ]; then
+        return "$SUCCESS"
+    fi
+
+    if [ "$dump_type_mapped" = "bmc" ]; then
+        dump_entry_id=$(echo "$dump_entry_id" | sed "s/^0*//")
+    fi
+
+    local DBUS_DUMP_MANAGER="xyz.openbmc_project.Dump.Manager"
+    local DBUS_DUMP_PATH="/xyz/openbmc_project/dump/$dump_type_mapped/entry/$dump_entry_id"
+    local DBUS_DUMP_ORIGINATROR_IFACE="xyz.openbmc_project.Common.OriginatedBy"
+    local DBUS_ORIGINATOR_TYPE_STRING="OriginatorType"
+    local DBUS_ORIGINATOR_ID_STRING="OriginatorId"
+
+    ORIGINATOR_TYPE=$(busctl get-property "$DBUS_DUMP_MANAGER" \
+            "$DBUS_DUMP_PATH" "$DBUS_DUMP_ORIGINATROR_IFACE" \
+        "$DBUS_ORIGINATOR_TYPE_STRING")
+
+    ORIGINATOR_ID=$(busctl get-property "$DBUS_DUMP_MANAGER" \
+            "$DBUS_DUMP_PATH" "$DBUS_DUMP_ORIGINATROR_IFACE" \
+        "$DBUS_ORIGINATOR_ID_STRING")
+
+    # The following two lines would extract the originator type and id
+    # from the received long string in response of the above dbus calls
+    # like <s "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Internal">
+    # to only <Internal> for the originator type and so on for the originator ID
+    ORIGINATOR_TYPE=$(echo "$ORIGINATOR_TYPE" | cut -d' ' -f 2 \
+        | cut -d'.' -f 6 | cut -d'"' -f 1)
+
+    ORIGINATOR_ID=$(echo "$ORIGINATOR_ID" | cut -d' ' -f 2 \
+        | cut -d'"' -f 1)
+
+    # This hash map for Originator Type is populated based on
+    # the info provided by the OriginatedBy.interface.yaml file under
+    # https://github.com/openbmc/phosphor-dbus-interfaces/
+    # Feel free to amend the table as per the evolving requirement
+    local -A originator_type_enum_map
+    originator_type_enum_map["Client"]=0
+    originator_type_enum_map["Internal"]=1
+    originator_type_enum_map["SupportingService"]=2
+
+    local originator_type_mapped="$ORIGINATOR_TYPE"
+    # If the originator type comes something which is not known to
+    # the enum list/map then make it blank so that can be filled
+    # with null bytes in gendumpheader script and won't be
+    # breaking the dump extraction
+    ORIGINATOR_TYPE=""
+    for key in "${!originator_type_enum_map[@]}"
+    do
+        if [ "$key" = "$originator_type_mapped" ]; then
+            ORIGINATOR_TYPE="${originator_type_enum_map[$key]}"
+            break
+        fi
+    done
+}
+

--- a/dump/tools/opdump/opdreport
+++ b/dump/tools/opdump/opdreport
@@ -73,6 +73,9 @@ dDay=$(date -d @"$EPOCHTIME" +'%Y%m%d%H%M%S')
 declare -x dump_content_type=""
 declare -x FILE=""
 
+#Source opdreport common functions
+. $DREPORT_INCLUDE/opfunctions
+
 # @brief Get serial number property from inventory
 function fetch_serial_number() {
     serialNo=$(busctl get-property "$INVENTORY_MANAGER" "$INVENTORY_PATH" \
@@ -108,6 +111,8 @@ function initialize() {
     else
         dump_size=$UNLIMITED
     fi
+
+    get_originator_details
 
     return "$SUCCESS"
 }


### PR DESCRIPTION
There are two parameters available for each dump,
Originator ID and Originator Type. This change
aims to include these fields into the BMC dump
header.

If for any reason either the originator ID or
originator type or both are unavailable then
they are been replaced by their allocated null
bytes.

Test Results:
Tested on generated BMC dumps and verified.