### PR TITLE
opfunctions: Fix dumpId length

### DIFF
--- a/dump/tools/common/include/opfunctions
+++ b/dump/tools/common/include/opfunctions
@@ -20,7 +20,7 @@ function fetch_serial_number() {
 # @param BMC Dump File Name
 function get_bmc_dump_filename() {
     fetch_serial_number
-    dump_id=$(printf %07d $dump_id)
+    dump_id=$(printf %08d $dump_id)
     if [ $dump_type = "$TYPE_FAULTDATA" ]; then
         header_dump_name="FLTDUMP"
         name="NAGDUMP.${serialNo}.${dump_id}.${dDay}"


### PR DESCRIPTION
Dump Id in BMC Dump Filename is padded to 7 digits instead of 8 digits. This is causing file name mismatch between the dump offloaded to HMC/OS and the dump stored on BMC. Fixing this issue by padding Dump Id to 8 digits.

Test Results:

Before:
root@p10bmc:/var/lib/phosphor-debug-collector/dumps/6# ls BMCDUMP.13ECF8X.0000006.20241001051003

After:
root@p10bmc:/var/lib/phosphor-debug-collector/dumps/17# ls BMCDUMP.1012345.00000017.20330125023119

Change-Id: I04c469ad3aaf6480c5732445ba7f8e644357262e