### PR TITLE
Add error information to dump on collection failures

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -1,6 +1,7 @@
 dump/tools/bmcdump/plugins/badpel
 dump/tools/bmcdump/plugins/cfam
 dump/tools/bmcdump/plugins/dumpfilelist
+dump/tools/bmcdump/plugins/faultlog
 dump/tools/bmcdump/plugins/guardlist
 dump/tools/bmcdump/plugins/obmcconsole1
 dump/tools/bmcdump/plugins/occ

--- a/dump/create_pel.hpp
+++ b/dump/create_pel.hpp
@@ -56,10 +56,21 @@ openpower::dump::pel::Severity convertSeverityToEnum(uint8_t severity);
  * @param[in] event - The event identifier associated with the PELs.
  * @param[out] pelAdditionalData - A reference to additional PEL data to be
  *                                 included in the PEL.
+ * @return logIdList - List of Errors created
  */
-void processFFDCPackets(const openpower::phal::sbeError_t& sbeError,
-                        const std::string& event,
-                        openpower::dump::pel::FFDCData& pelAdditionalData);
+std::vector<uint32_t>
+    processFFDCPackets(const openpower::phal::sbeError_t& sbeError,
+                       const std::string& event,
+                       openpower::dump::pel::FFDCData& pelAdditionalData);
+
+/**
+ * @brief Get PEL Id and Reason Code for a given logEntry
+ *
+ * @param[in] logId - dbus entry id.
+ *
+ * @return Platform Event Log Id, Reason Code
+ */
+std::tuple<uint32_t, std::string> getLogInfo(uint32_t logId);
 
 /**
  * @class FFDCFile

--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -59,7 +59,7 @@ void SbeDumpCollector::collectDump(uint8_t type, uint32_t id,
         // if the dump type is hostboot then call stop instructions
         if (type == SBE_DUMP_TYPE_HOSTBOOT)
         {
-            includeTarget = executeThreadStop(target);
+            includeTarget = executeThreadStop(target, path);
         }
         if (includeTarget)
         {
@@ -187,7 +187,8 @@ std::vector<std::future<void>> SbeDumpCollector::spawnDumpCollectionProcesses(
 
 bool SbeDumpCollector::logErrorAndCreatePEL(
     const openpower::phal::sbeError_t& sbeError, uint64_t chipPos,
-    SBETypes sbeType, uint32_t cmdClass, uint32_t cmdType)
+    SBETypes sbeType, uint32_t cmdClass, uint32_t cmdType,
+    const std::filesystem::path& path)
 {
     namespace fs = std::filesystem;
 
@@ -246,8 +247,22 @@ bool SbeDumpCollector::logErrorAndCreatePEL(
                            "POSITION", chipPos);
             }
             // Processor FFDC Packets
-            openpower::dump::pel::processFFDCPackets(sbeError, event,
-                                                     pelAdditionalData);
+            std::vector<uint32_t> logIdList =
+                openpower::dump::pel::processFFDCPackets(sbeError, event,
+                                                         pelAdditionalData);
+            for (auto logId : logIdList)
+            {
+                try
+                {
+                    auto logInfo = openpower::dump::pel::getLogInfo(logId);
+                    addLogDataToDump(std::get<0>(logInfo), std::get<1>(logInfo),
+                                     chipName, chipPos, path.parent_path());
+                }
+                catch (const std::exception& e)
+                {
+                    lg2::error("Failed to get error Info");
+                }
+            }
         }
 
         // If dump is required, request it
@@ -255,7 +270,18 @@ bool SbeDumpCollector::logErrorAndCreatePEL(
         {
             auto logId = openpower::dump::pel::createSbeErrorPEL(
                 event, sbeError, pelAdditionalData);
-            util::requestSBEDump(chipPos, logId, sbeType);
+            try
+            {
+                auto logInfo = openpower::dump::pel::getLogInfo(logId);
+                addLogDataToDump(std::get<0>(logInfo), std::get<1>(logInfo),
+                                 chipName, chipPos, path.parent_path());
+                util::requestSBEDump(chipPos, std::get<0>(logInfo), sbeType);
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error(
+                    "Failed to get error Info, failed to create sbe dump");
+            }
         }
     }
     catch (const std::out_of_range& e)
@@ -317,7 +343,8 @@ void SbeDumpCollector::collectDumpFromSBE(struct pdbg_target* chip,
         // then create PELs with FFDC but write the dump contents to the
         // file.
         if (logErrorAndCreatePEL(sbeError, chipPos, sbeType,
-                                 SBEFIFO_CMD_CLASS_DUMP, SBEFIFO_CMD_GET_DUMP))
+                                 SBEFIFO_CMD_CLASS_DUMP, SBEFIFO_CMD_GET_DUMP,
+                                 path))
         {
             lg2::error("Error in collecting dump dump type({TYPE}), "
                        "clockstate({CLOCKSTATE}), chip type({CHIPTYPE}) "
@@ -395,7 +422,8 @@ void SbeDumpCollector::writeDumpFile(
     }
 }
 
-bool SbeDumpCollector::executeThreadStop(struct pdbg_target* target)
+bool SbeDumpCollector::executeThreadStop(struct pdbg_target* target,
+                                         const std::filesystem::path& path)
 {
     try
     {
@@ -420,7 +448,7 @@ bool SbeDumpCollector::executeThreadStop(struct pdbg_target* target)
 
         logErrorAndCreatePEL(sbeError, chipPos, SBETypes::PROC,
                              SBEFIFO_CMD_CLASS_INSTRUCTION,
-                             SBEFIFO_CMD_CONTROL_INSN);
+                             SBEFIFO_CMD_CONTROL_INSN, path);
         // For TIMEOUT, log the error and skip adding the processor for dump
         // collection
         if (sbeError.errType() == openpower::phal::exception::SBE_CMD_TIMEOUT)
@@ -431,6 +459,25 @@ bool SbeDumpCollector::executeThreadStop(struct pdbg_target* target)
     // Include the target for dump collection for SBE_CMD_FAILED or any other
     // non-critical errors
     return true;
+}
+
+void SbeDumpCollector::addLogDataToDump(uint32_t pelId, std::string src,
+                                        std::string chipName, uint64_t chipPos,
+                                        const std::filesystem::path& path)
+{
+    std::filesystem::path info = path / "info.yaml";
+    std::ofstream fout(info);
+    if (!fout)
+    {
+        lg2::error("Error: Failed to open the file! {FILE}", "FILE", info);
+        lg2::error("No error Info is added to dump file");
+        return;
+    }
+    fout << "ErrorInfo:" << std::endl;
+    fout << " PELId: " << pelId << std::endl;
+    fout << " src: " << src << std::endl;
+    auto resource = chipName + " " + std::to_string(chipPos);
+    fout << " Resource: " << resource << std::endl;
 }
 
 } // namespace openpower::dump::sbe_chipop

--- a/dump/sbe_dump_collector.hpp
+++ b/dump/sbe_dump_collector.hpp
@@ -176,11 +176,13 @@ class SbeDumpCollector
      * message.
      * @param cmdClass - The command class associated with the SBE operation.
      * @param cmdType - The specific type of command within the command class.
+     * @param path - Dump collection path.
      *
      */
     bool logErrorAndCreatePEL(const openpower::phal::sbeError_t& sbeError,
                               uint64_t chipPos, SBETypes sbeType,
-                              uint32_t cmdClass, uint32_t cmdType);
+                              uint32_t cmdClass, uint32_t cmdType,
+                              const std::filesystem::path& path);
 
     /**
      * Determines the type of SBE for a given chip target.
@@ -209,13 +211,26 @@ class SbeDumpCollector
      *
      * @param target Pointer to the pdbg target structure representing the
      *               processor to perform the thread stop on.
+     * @param path Dump collection path
      * @return true If the thread stop was successful or in case of non-critical
      *              errors where dump collection can proceed.
      * @return false If the SBE is not ready for chip-ops or in case of critical
      *               errors like timeouts, indicating the processor should be
      *               excluded from the dump collection.
      */
-    bool executeThreadStop(struct pdbg_target* target);
+    bool executeThreadStop(struct pdbg_target* target,
+                           const std::filesystem::path& path);
+
+    /**
+     * @brief Add Failure log information to info.yaml file
+     * @param logId - Error Log Id
+     * @param src - Reason Code of PEL
+     * @param chipName - Resource Name
+     * @param chipPos - Resource number
+     * @param path - Dump collection path
+     */
+    void addLogDataToDump(uint32_t logId, std::string src, std::string chipName,
+                          uint64_t chipPos, const std::filesystem::path& path);
 };
 
 } // namespace openpower::dump::sbe_chipop

--- a/dump/tools/common/include/gendumpheader
+++ b/dump/tools/common/include/gendumpheader
@@ -59,7 +59,7 @@ function add_originator_details() {
         nulltoadd=$(( SIZE_4 - len ))
         printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
         if [ "$nulltoadd" -gt 0 ]; then
-             add_null "$nulltoadd"
+            add_null "$nulltoadd"
         fi
     fi
 
@@ -70,7 +70,7 @@ function add_originator_details() {
         nulltoadd=$(( SIZE_32 - len ))
         printf '%s' "$ORIGINATOR_ID" >> "$FILE"
         if [ "$nulltoadd" -gt 0 ]; then
-             add_null "$nulltoadd"
+            add_null "$nulltoadd"
         fi
     fi
 }


### PR DESCRIPTION
Test Results:

root@p10bmc:/tmp/test# cat /tmp/dump_20000005_1737700066/info.yaml ErrorInfo:
 PELId: 1342183604
 src: BD123501
 Resource: proc 1

Change-Id: I920d646e2533a8fa7ae1aed42d63a9e4bac7f771