### PR TITLE
dump: Fix info.yaml to work with makedump tool

### DIFF
--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -465,19 +465,25 @@ void SbeDumpCollector::addLogDataToDump(uint32_t pelId, std::string src,
                                         std::string chipName, uint64_t chipPos,
                                         const std::filesystem::path& path)
 {
-    std::filesystem::path info = path / "info.yaml";
-    std::ofstream fout(info);
+    std::filesystem::path info = path / "errorInfo";
+    auto fileExists = std::filesystem::exists(info);
+    std::ofstream fout;
+    fout.open(info, std::ios::app);
     if (!fout)
     {
         lg2::error("Error: Failed to open the file! {FILE}", "FILE", info);
         lg2::error("No error Info is added to dump file");
         return;
     }
-    fout << "ErrorInfo:" << std::endl;
-    fout << " PELId: " << pelId << std::endl;
-    fout << " src: " << src << std::endl;
+    if (!fileExists)
+    {
+        fout << "ErrorInfo:" << std::endl;
+    }
+    auto pel = " " + std::format("{:08x}", pelId) + ":";
+    fout << pel << std::endl;
+    fout << "  src: " << src << std::endl;
     auto resource = chipName + " " + std::to_string(chipPos);
-    fout << " Resource: " << resource << std::endl;
+    fout << "  Resource: " << resource << std::endl;
 }
 
 } // namespace openpower::dump::sbe_chipop

--- a/dump/tools/common/include/gendumpinfo
+++ b/dump/tools/common/include/gendumpinfo
@@ -79,6 +79,7 @@ function write_to_info_file() {
     } >> "$YAML_FILE"
     dump_time_details
     get_addl_data
+    cat "$content_path/errorInfo" >> "$YAML_FILE"
 }
 
 # Run main


### PR DESCRIPTION
Recently there was a requirement to add dump collection failures to info.yaml file. This has caused an issue in makedump tool parsing as the ErrorInfo details are added as a separate document. Fixing this by appending ErrorInfo details at the end of info.yaml file.

Change-Id: I74c2fb8ebc31d1c3bd60feffa3f0467faa435d5c