### PR TITLE
opdreport: add host preserved partitions to BMC dump

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -9,6 +9,7 @@ dump/tools/bmcdump/plugins/occ
 dump/tools/bmcdump/plugins/pels
 dump/tools/bmcdump/plugins/phal_devtree
 dump/tools/bmcdump/plugins/vpd_data
+dump/tools/bmcdump/plugins/hostboot
 dump/tools/bmcdump/scripts/package
 dump/tools/common/include/gendumpheader
 dump/tools/common/include/gendumpinfo

--- a/dump/tools/bmcdump/plugins/hostboot
+++ b/dump/tools/bmcdump/plugins/hostboot
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# config: 234 60
+# @brief: Collect host firmware preserved partitions to BMC dump
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+#HBEL=Hostboot Error log
+#HBD_RW=Hostboot preserved attributes
+#EECACHE=Hostboot VPD EECACHE
+partitions=("HBEL" "HBD_RW" "EECACHE")
+for i in "${partitions[@]}"; do
+    filename="/var/lib/phosphor-software-manager/hostfw/running/$i"
+    if [ -f "$filename" ]; then
+        add_copy_file "$filename" "$partition"
+    fi
+done


### PR DESCRIPTION
This change is picked from
https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/52594

HBEL    (Hostboot error logs)
HBD_RW  (Hostboot preserved attributes)
EECACHE (Hostboot VPD cache)

Tested:
```
Wed Apr 13 08:13:31 UTC 2022 INFO: Copied HBEL /media/hostfw/running/HBEL
Wed Apr 13 08:13:31 UTC 2022 INFO: Copied HBD_RW /media/hostfw/running/HBD_RW
Wed Apr 13 08:13:31 UTC 2022 INFO: Copied EECACHE /media/hostfw/running/EECACHE

root@rain104bmc:/tmp/test/obmcdump_00000000_1649837600# ls -la HBEL
-rw-r-----    1 root     root        147456 Apr 13 08:13 HBEL
root@rain104bmc:/tmp/test/obmcdump_00000000_1649837600# ls -lah HBEL
-rw-r-----    1 root     root      144.0K Apr 13 08:13 HBEL
-rw-r-----    1 root     root        2.0M Apr 13 08:13 HBD_RW
root@rain104bmc:/tmp/test/obmcdump_00000000_1649837600# ls -lah EECACHE
-rw-r-----    1 root     root        2.8M Apr 13 08:13 EECACHE
```

Change-Id: Icaa065540e940f26a930e27db8d94fa4c4a19c88