### PR TITLE
tools: Add Python-based dumptool CLI for dump management

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,42 @@ if get_option('dump-collection').allowed()
     subdir('dump')
 endif
 
+# Install dumptool Python package for phal-next backend
+if phal_backend == 'next'
+    python = import('python').find_installation('python3')
+    
+    # Install the dumptool package
+    python.install_sources(
+        'tools/dumptool/__init__.py',
+        'tools/dumptool/__main__.py',
+        'tools/dumptool/cli.py',
+        'tools/dumptool/models.py',
+        subdir: 'dumptool',
+    )
+    
+    python.install_sources(
+        'tools/dumptool/clients/__init__.py',
+        'tools/dumptool/clients/dbus_client.py',
+        subdir: 'dumptool/clients',
+    )
+    
+    python.install_sources(
+        'tools/dumptool/services/__init__.py',
+        'tools/dumptool/services/dump_service.py',
+        subdir: 'dumptool/services',
+    )
+    
+    # Create wrapper script in /usr/bin
+    configure_file(
+        input: 'tools/dumptool-wrapper.sh',
+        output: 'dumptool',
+        configuration: configuration_data(),
+        install: true,
+        install_dir: get_option('bindir'),
+        install_mode: 'rwxr-xr-x',
+    )
+endif
+
 deps = [CLI11_dep, sdbusplus_dep, phosphorlogging, extra_deps]
 
 executable(

--- a/tools/dumptool-wrapper.sh
+++ b/tools/dumptool-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper script to run dumptool as a Python module
+exec python3 -m dumptool.cli "$@"
+

--- a/tools/dumptool/__init__.py
+++ b/tools/dumptool/__init__.py
@@ -1,0 +1,3 @@
+"""Dump Management Tool for OpenBMC"""
+__version__ = "1.0.0"
+

--- a/tools/dumptool/__main__.py
+++ b/tools/dumptool/__main__.py
@@ -1,0 +1,6 @@
+
+from dumptool.cli import main
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/dumptool/cli.py
+++ b/tools/dumptool/cli.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import argparse
+from dumptool.services.dump_service import DumpService
+from dumptool.models import DumpType
+
+service = DumpService()
+
+
+def list_dumps(filter_type):
+    dumps = service.list_dumps()
+
+    print(f"{'ID':<10} {'Type':<12} {'Size(KB)':<12} {'Start Time':<20} {'End Time':<20} {'Status':<15}")
+
+    for d in dumps:
+        if filter_type and d.type.value != filter_type:
+            continue
+
+        size_kb = d.size_kb
+        status = d.status
+
+        print(f"{d.id:<10} {d.final_type:<12} {size_kb:<12} {str(d.started_time or '-'): <20} {str(d.ended_time or '-'): <20} {status:<15}")
+
+
+def create_dump(dump_type):
+    try:
+        service.create_dump(DumpType(dump_type))
+        print("✔ Dump created successfully")
+    except Exception as e:
+        print(f"✖ Failed to create dump: {e}")
+
+
+def delete_dump(dump_id):
+    try:
+        service.delete_dump(dump_id)
+        print("Dump deleted successfully")
+    except ValueError:
+        print("Dump not found")
+
+
+def get_dump_info(dump_id):
+    try:
+        info = service.get_dump_info(dump_id)
+
+        print(f"ID           : {info.id}")
+        print(f"Type         : {info.final_type}")
+        print(f"Size (KB)    : {info.size_kb}")
+        print(f"Start Time   : {info.started_time or 'N/A'}")
+        print(f"End Time     : {info.ended_time or 'N/A'}")
+        print(f"Status       : {info.status}")
+        print(f"Offloaded    : {info.offloaded}")
+
+    except ValueError:
+        print("✖ Dump not found")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dump Management Tool")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # list
+    list_parser = subparsers.add_parser("list", help="List all dumps")
+    list_parser.add_argument("--type", help="Filter by dump type")
+
+    # create
+    create_parser = subparsers.add_parser("create", help="Create a dump")
+    create_parser.add_argument("--type", default="bmc", help="Dump type")
+
+    # delete
+    delete_parser = subparsers.add_parser("delete", help="Delete a dump")
+    delete_parser.add_argument("dump_id", type=int, help="Dump ID")
+
+    # get-info
+    info_parser = subparsers.add_parser("get-info", help="Get dump details")
+    info_parser.add_argument("dump_id", type=int, help="Dump ID")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        list_dumps(args.type)
+
+    elif args.command == "create":
+        create_dump(args.type)
+
+    elif args.command == "delete":
+        delete_dump(args.dump_id)
+
+    elif args.command == "get-info":
+        get_dump_info(args.dump_id)
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/tools/dumptool/clients/__init__.py
+++ b/tools/dumptool/clients/__init__.py
@@ -1,0 +1,2 @@
+"""DBus client module"""
+

--- a/tools/dumptool/clients/dbus_client.py
+++ b/tools/dumptool/clients/dbus_client.py
@@ -1,0 +1,152 @@
+import subprocess
+import datetime
+from typing import List, Dict
+from dumptool.models import DumpEntry, DumpType, DumpInfo
+
+class DBusClient:
+    BUSNAME = "xyz.openbmc_project.Dump.Manager"
+
+    #List Dumps
+    def list_dumps(self) -> List[DumpEntry]:
+        result = subprocess.run(
+            ["busctl", "tree", self.BUSNAME],
+            capture_output=True,
+            text=True
+        )
+
+        dumps = []
+
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+
+            if "/xyz/openbmc_project/dump/" in line and "/entry/" in line:
+                path = line.split()[-1]
+
+                try:
+                    dump_id = int(path.split("/")[-1])
+                    dumps.append(
+                        DumpEntry(
+                            id=dump_id,
+                            type=DumpType.from_path(path),
+                            object_path=path
+                        )
+                    )
+                except ValueError:
+                    continue
+
+        return dumps
+
+    #Create Dump
+    def create_dump(self, dump_type: DumpType, params: Dict = {}) -> str:
+        result = subprocess.run(
+            [
+                "busctl", "call",
+                self.BUSNAME,
+                dump_type.object_path,
+                "xyz.openbmc_project.Dump.Create",
+                "CreateDump",
+                "a{sv}", "0"
+            ],
+            capture_output=True,
+            text=True
+        )
+
+        print("STDOUT:", result.stdout)
+        return result.stdout.strip()
+
+    #Delete Dump
+    def delete_dump(self, object_path: str) -> bool:
+        result = subprocess.run(
+            [
+                "busctl", "call",
+                self.BUSNAME,
+                object_path,
+                "xyz.openbmc_project.Object.Delete",
+                "Delete"
+            ],
+            capture_output=True,
+            text=True
+        )
+
+        return result.returncode == 0
+
+    #Get Dump Info
+    def get_dump_info(self, object_path: str) -> DumpInfo:
+
+        def get_property(prop, interface):
+            result = subprocess.run(
+                [
+                    "busctl", "get-property",
+                    self.BUSNAME,
+                    object_path,
+                    interface,
+                    prop
+                ],
+                capture_output=True,
+                text=True
+            )
+
+            if result.returncode != 0:
+                return None
+
+            output = result.stdout.strip().split()
+
+            if len(output) < 2:
+                return None
+
+            dtype, value = output[0], output[1]
+
+            if dtype == "b":
+                return value.lower() == "true"
+            elif dtype in ["u", "t", "x"]:
+                return int(value)
+            else:
+                return value
+
+        def format_time(value):
+            if not value or value == 0:
+                return None
+            try:
+                ts = int(value) / 1_000_000
+
+                dt = datetime.datetime.utcfromtimestamp(ts)
+
+                return dt.strftime("%Y-%m-%d %H:%M:%S")
+            except:
+                return str(value)
+
+        def parse_status(status_raw):
+            if not status_raw:
+                return None
+            if "Completed" in status_raw:
+                return True
+            elif "InProgress" in status_raw:
+                return False
+            return None
+
+
+        size = get_property("Size", "xyz.openbmc_project.Dump.Entry")
+        offloaded = get_property("Offloaded", "xyz.openbmc_project.Dump.Entry")
+
+        started_time_raw = get_property("StartTime", "xyz.openbmc_project.Common.Progress")
+        ended_time_raw = get_property("CompletedTime", "xyz.openbmc_project.Common.Progress")
+        status_raw = get_property("Status", "xyz.openbmc_project.Common.Progress")
+
+
+        completed = parse_status(status_raw)
+        started_time = format_time(started_time_raw)
+        ended_time = format_time(ended_time_raw)
+
+        dump_id = int(object_path.split("/")[-1])
+        dump_type = DumpType.from_path(object_path)
+
+        return DumpInfo(
+            id=dump_id,
+            type=dump_type,
+            size=size,
+            completed=completed,
+            offloaded=offloaded,
+            started_time=started_time,
+            ended_time=ended_time
+        )
+

--- a/tools/dumptool/models.py
+++ b/tools/dumptool/models.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class DumpType(Enum):
+    BMC = "bmc"
+    SYSTEM = "system"
+    RESOURCE = "resource"
+    FAULTLOG = "faultlog"
+
+    @property
+    def object_path(self) -> str:
+        return f"/xyz/openbmc_project/dump/{self.value}"
+
+    @staticmethod
+    def from_path(path: str):
+        if "/dump/bmc/" in path:
+            return DumpType.BMC
+        elif "/dump/system/" in path:
+            return DumpType.SYSTEM
+        elif "/dump/resource/" in path:
+            return DumpType.RESOURCE
+        elif "/dump/faultlog/" in path:
+            return DumpType.FAULTLOG
+        else:
+            raise ValueError("Unknown dump type")
+
+
+@dataclass
+class DumpEntry:
+    id: int
+    type: DumpType
+    object_path: str
+
+    @property
+    def final_type(self) -> str:
+        if self.type == DumpType.BMC:
+            return "bmc"
+        if self.type == DumpType.SYSTEM:
+            if self.id >= 30000000:
+                return "sbe"
+            elif self.id >= 20000000:
+                return "hostboot"
+            else:
+                return "system"
+        return self.type.value
+
+
+@dataclass
+class DumpInfo:
+    id: int
+    type: DumpType
+    size: Optional[int] = None
+    completed: Optional[bool] = None
+    offloaded: Optional[bool] = None
+    started_time: Optional[str] = None
+    ended_time: Optional[str] = None
+
+    @property
+    def final_type(self) -> str:
+        if self.type == DumpType.BMC:
+            return "bmc"
+        if self.type == DumpType.SYSTEM:
+            if self.id >= 30000000:
+                return "sbe"
+            elif self.id >= 20000000:
+                return "hostboot"
+            else:
+                return "system"
+        return self.type.value
+
+    @property
+    def size_kb(self):
+        return f"{self.size // 1024} KB" if self.size else "-"
+
+    @property
+    def status(self):
+        if self.completed is None:
+            return "Unknown"
+        return "Completed" if self.completed else "In Progress"
+
+# Made with Bob

--- a/tools/dumptool/services/__init__.py
+++ b/tools/dumptool/services/__init__.py
@@ -1,0 +1,2 @@
+"""Dump service module"""
+

--- a/tools/dumptool/services/dump_service.py
+++ b/tools/dumptool/services/dump_service.py
@@ -1,0 +1,35 @@
+from dumptool.clients.dbus_client import DBusClient
+from dumptool.models import DumpType, DumpInfo
+from typing import List
+
+
+class DumpService:
+    def __init__(self):
+        self.client = DBusClient()
+
+    def list_dumps(self) -> List[DumpInfo]:
+        dumps = self.client.list_dumps()
+        return [self.client.get_dump_info(d.object_path) for d in dumps]
+
+    def create_dump(self, dump_type: DumpType) -> str:
+        return self.client.create_dump(dump_type)
+
+    def delete_dump(self, dump_id: int) -> bool:
+        dumps = self.client.list_dumps()
+        dump = next((d for d in dumps if d.id == dump_id), None)
+
+        if not dump:
+            raise ValueError(f"Dump ID {dump_id} not found")
+
+        return self.client.delete_dump(dump.object_path)
+
+    def get_dump_info(self, dump_id: int) -> DumpInfo:
+        dumps = self.client.list_dumps()
+        dump = next((d for d in dumps if d.id == dump_id), None)
+
+        if not dump:
+            raise ValueError(f"Dump ID {dump_id} not found")
+
+        return self.client.get_dump_info(dump.object_path)
+
+


### PR DESCRIPTION
Introduces a Python command-line tool for managing OpenBMC dumps when using the phal-next backend. The tool provides operations to list, create, delete, and query dump information through D-Bus communication.

Key features:

CLI with argparse for dump operations (list/create/delete/get-info) D-Bus client layer using busctl for communication with xyz.openbmc_project.Dump.Manager Data models supporting BMC, SYSTEM, RESOURCE, and FAULTLOG dump types Intelligent dump type detection (SBE, Hostboot, System) based on ID ranges Service layer for business logic and error handling Meson build integration for phal-next backend
Wrapper script installed as 'dumptool' command in /usr/bin

Usage:

dumptool list [--type TYPE]
dumptool create --type TYPE
dumptool delete DUMP_ID
dumptool get-info DUMP_ID# Please enter the commit message for your changes. Lines starting

Change-Id: I5bafd37b7315aaade007365dd1680ffae4193069