### PR TITLE
phal: add getNodeNum() for multi-node dump support

### DIFF
--- a/dump/sbe_dump_collector.cpp
+++ b/dump/sbe_dump_collector.cpp
@@ -418,8 +418,9 @@ void SbeDumpCollector::collectDumpFromSBE(
         auto dumpData =
             phal_chipop::getDump(chip, type, clockState, collectFastArray);
 
+        auto nodeNum = phal_tgt::getNodeNum(chip);
         // Pass byte span directly — no extra copy needed
-        writeDumpFile(path, id, clockState, 0, chipName, chipPos,
+        writeDumpFile(path, id, clockState, nodeNum, chipName, chipPos,
                       dumpData.bytes());
     }
     catch (const phal_chipop::ChipOpError& chipOpError)

--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,7 @@ endif
 # Install dumptool Python package for phal-next backend
 if phal_backend == 'next'
     python = import('python').find_installation('python3')
-    
+
     # Install the dumptool package
     python.install_sources(
         'tools/dumptool/__init__.py',
@@ -64,17 +64,17 @@ if phal_backend == 'next'
         'tools/dumptool/models.py',
         subdir: 'dumptool',
     )
-    
+
     python.install_sources(
         'tools/dumptool/clients/dbus_client.py',
         subdir: 'dumptool/clients',
     )
-    
+
     python.install_sources(
         'tools/dumptool/services/dump_service.py',
         subdir: 'dumptool/services',
     )
-    
+
     # Create wrapper script in /usr/bin
     configure_file(
         input: 'tools/dumptool-wrapper.sh',

--- a/phal/targeting_iface.hpp
+++ b/phal/targeting_iface.hpp
@@ -117,6 +117,17 @@ bool isUsable(TargetHandle target);
 uint32_t chipPos(TargetHandle target);
 
 /**
+ * @brief Get node number
+ *
+ * Legacy: 0
+ * Next: getParentTarget's ATTR_FAPI_POS via utils::getFapiPos()
+ *
+ * @param target Target handle
+ * @return Node number
+ */
+uint32_t getNodeNum(TargetHandle target);
+
+/**
  * @brief Get target chip type (semantic classification)
  *
  * Legacy: is_ody_ocmb_chip() to classify

--- a/phal/targeting_legacy.cpp
+++ b/phal/targeting_legacy.cpp
@@ -86,6 +86,11 @@ uint32_t chipPos(TargetHandle target)
     return pdbg_target_index(target);
 }
 
+uint32_t getNodeNum(TargetHandle target)
+{
+    return 0;
+}
+
 ChipType getChipType(TargetHandle target)
 {
     if (is_ody_ocmb_chip(target))

--- a/phal/targeting_next.cpp
+++ b/phal/targeting_next.cpp
@@ -122,8 +122,33 @@ uint32_t chipPos(TargetHandle target)
 
     try
     {
-        // Get FAPI position (matches failingUnit semantics)
         return TARGETING::utils::getPosition(target);
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("PHAL Next: chipPos failed: {ERROR}", "ERROR", ex.what());
+        return 0;
+    }
+}
+
+uint32_t getNodeNum(TargetHandle target)
+{
+    if (target == nullptr)
+    {
+        return 0;
+    }
+
+    auto parentTarget =
+        TARGETING::utils::getParentTarget(target, TARGETING::TYPE_NODE);
+    if (parentTarget == nullptr)
+    {
+        return 0;
+    }
+
+    try
+    {
+        // Get FAPI position (matches failingUnit semantics)
+        return TARGETING::utils::getFapiPos(parentTarget);
     }
     catch (const std::exception& ex)
     {

--- a/tools/dumptool/README.md
+++ b/tools/dumptool/README.md
@@ -1,23 +1,29 @@
 # dumptool
 
-A Python command-line tool for managing OpenBMC dumps on systems using the phal-next backend.
+A Python command-line tool for managing OpenBMC dumps on systems using the
+phal-next backend.
 
 ## Overview
 
-`dumptool` simplifies dump management on OpenBMC systems by providing an intuitive command-line interface for common dump operations. 
+`dumptool` simplifies dump management on OpenBMC systems by providing an
+intuitive command-line interface for common dump operations.
 
 ### Why dumptool?
 
-On OpenBMC systems, dumps are critical for debugging hardware and firmware issues. However, managing these dumps traditionally requires:
+On OpenBMC systems, dumps are critical for debugging hardware and firmware
+issues. However, managing these dumps traditionally requires:
+
 - Complex D-Bus commands with lengthy object paths
 - Knowledge of specific D-Bus interfaces and methods
 - Manual parsing of D-Bus output
 
 `dumptool` addresses these challenges by:
+
 - **Simplifying Operations**: Single commands replace complex D-Bus calls
 - **Improving Usability**: Clear, formatted output instead of raw D-Bus data
 - **Reducing Errors**: Type validation and helpful error messages
-- **Saving Time**: Quick access to dump information without memorizing D-Bus paths
+- **Saving Time**: Quick access to dump information without memorizing D-Bus
+  paths
 
 ### What it does
 
@@ -25,7 +31,8 @@ On OpenBMC systems, dumps are critical for debugging hardware and firmware issue
 - **Create dumps**: Generate BMC, system, resource, or faultlog dumps on demand
 - **Query dumps**: Get detailed information about specific dumps
 - **Delete dumps**: Clean up old or unnecessary dumps
-- **Smart categorization**: Automatically identifies hostboot and SBE dumps based on ID ranges
+- **Smart categorization**: Automatically identifies hostboot and SBE dumps
+  based on ID ranges
 
 ## Usage
 
@@ -36,39 +43,53 @@ dumptool <command> [options]
 ## Commands
 
 ### help
+
 Display help information.
+
 ```bash
 dumptool --help
 dumptool -h
 ```
 
 ### list
+
 List all dumps or filter by type.
+
 ```bash
 dumptool list [--type TYPE]
 ```
+
 - `--type`: Optional filter (bmc, system, resource, faultlog)
 
 ### create
+
 Create a new dump.
+
 ```bash
 dumptool create [--type TYPE]
 ```
+
 - `--type`: Dump type to create (default: bmc)
   - Accepted values: bmc, system, resource, faultlog
 
 ### delete
+
 Delete a dump by ID.
+
 ```bash
 dumptool delete DUMP_ID
 ```
+
 - `DUMP_ID`: Numeric ID of the dump to delete
 
 ### get-info
+
 Get detailed information about a specific dump.
+
 ```bash
 dumptool get-info DUMP_ID
 ```
+
 - `DUMP_ID`: Numeric ID of the dump
 
 ## Examples
@@ -76,6 +97,7 @@ dumptool get-info DUMP_ID
 ### Getting Help
 
 Display general help:
+
 ```bash
 $ dumptool --help
 usage: dumptool [-h] {list,create,delete,get-info} ...
@@ -94,6 +116,7 @@ optional arguments:
 ```
 
 Get help for the create command:
+
 ```bash
 $ dumptool create --help
 usage: dumptool create [-h] [--type TYPE]
@@ -106,6 +129,7 @@ optional arguments:
 ### Listing Dumps
 
 List all dumps:
+
 ```bash
 $ dumptool list
 ID         Type         Size(KB)     Start Time           End Time             Status
@@ -115,6 +139,7 @@ ID         Type         Size(KB)     Start Time           End Time             S
 ```
 
 List only BMC dumps:
+
 ```bash
 $ dumptool list --type bmc
 ID         Type         Size(KB)     Start Time           End Time             Status
@@ -122,6 +147,7 @@ ID         Type         Size(KB)     Start Time           End Time             S
 ```
 
 List only system dumps:
+
 ```bash
 $ dumptool list --type system
 ID         Type         Size(KB)     Start Time           End Time             Status
@@ -132,24 +158,28 @@ ID         Type         Size(KB)     Start Time           End Time             S
 ### Creating Dumps
 
 Create a BMC dump (default):
+
 ```bash
 $ dumptool create
 ✔ Dump created successfully
 ```
 
 Create a system dump:
+
 ```bash
 $ dumptool create --type system
 ✔ Dump created successfully
 ```
 
 Create a resource dump:
+
 ```bash
 $ dumptool create --type resource
 ✔ Dump created successfully
 ```
 
 Create a faultlog dump:
+
 ```bash
 $ dumptool create --type faultlog
 ✔ Dump created successfully
@@ -158,6 +188,7 @@ $ dumptool create --type faultlog
 ### Getting Dump Information
 
 Get details for a specific dump:
+
 ```bash
 $ dumptool get-info 1
 ID           : 1
@@ -170,6 +201,7 @@ Offloaded    : False
 ```
 
 Get details for a hostboot dump:
+
 ```bash
 $ dumptool get-info 20000001
 ID           : 20000001
@@ -184,12 +216,14 @@ Offloaded    : False
 ### Deleting Dumps
 
 Delete a dump by ID:
+
 ```bash
 $ dumptool delete 1
 Dump deleted successfully
 ```
 
 Delete multiple dumps:
+
 ```bash
 $ dumptool delete 1
 Dump deleted successfully
@@ -200,11 +234,13 @@ Dump deleted successfully
 ## Common Workflows
 
 Check for recent dumps:
+
 ```bash
 dumptool list
 ```
 
 Create and verify a BMC dump:
+
 ```bash
 dumptool create --type bmc
 dumptool list --type bmc
@@ -212,6 +248,7 @@ dumptool get-info <DUMP_ID>
 ```
 
 Clean up old dumps:
+
 ```bash
 dumptool list
 dumptool delete 1

--- a/tools/dumptool/__init__.py
+++ b/tools/dumptool/__init__.py
@@ -1,2 +1,3 @@
 """Dump Management Tool for OpenBMC"""
+
 __version__ = "1.0.0"

--- a/tools/dumptool/__main__.py
+++ b/tools/dumptool/__main__.py
@@ -1,4 +1,5 @@
 """Entry point for running dumptool as a module with python -m dumptool.cli"""
+
 from dumptool.cli import main
 
 if __name__ == "__main__":

--- a/tools/dumptool/cli.py
+++ b/tools/dumptool/cli.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import argparse
-from dumptool.services.dump_service import DumpService
+
 from dumptool.models import DumpType
+from dumptool.services.dump_service import DumpService
 
 service = DumpService()
 
@@ -9,7 +10,9 @@ service = DumpService()
 def list_dumps(filter_type):
     dumps = service.list_dumps()
 
-    print(f"{'ID':<10} {'Type':<12} {'Size(KB)':<12} {'Start Time':<20} {'End Time':<20} {'Status':<15}")
+    print(
+        f"{'ID':<10} {'Type':<12} {'Size(KB)':<12} {'Start Time':<20} {'End Time':<20} {'Status':<15}"
+    )
 
     for d in dumps:
         if filter_type and d.type.value != filter_type:
@@ -18,7 +21,9 @@ def list_dumps(filter_type):
         size_kb = d.size_kb
         status = d.status
 
-        print(f"{d.id:<10} {d.final_type:<12} {size_kb:<12} {str(d.started_time or '-'): <20} {str(d.ended_time or '-'): <20} {status:<15}")
+        print(
+            f"{d.id:<10} {d.final_type:<12} {size_kb:<12} {str(d.started_time or '-'): <20} {str(d.ended_time or '-'): <20} {status:<15}"
+        )
 
 
 def create_dump(dump_type):
@@ -64,7 +69,11 @@ def main():
 
     # create
     create_parser = subparsers.add_parser("create", help="Create a dump")
-    create_parser.add_argument("--type", default="bmc", help="Dump type (accepted values: bmc, system, resource, faultlog)")
+    create_parser.add_argument(
+        "--type",
+        default="bmc",
+        help="Dump type (accepted values: bmc, system, resource, faultlog)",
+    )
 
     # delete
     delete_parser = subparsers.add_parser("delete", help="Delete a dump")

--- a/tools/dumptool/clients/dbus_client.py
+++ b/tools/dumptool/clients/dbus_client.py
@@ -1,17 +1,17 @@
-import subprocess
 import datetime
-from typing import List, Dict
-from dumptool.models import DumpEntry, DumpType, DumpInfo
+import subprocess
+from typing import Dict, List, Optional
+
+from dumptool.models import DumpEntry, DumpInfo, DumpType
+
 
 class DBusClient:
     BUSNAME = "xyz.openbmc_project.Dump.Manager"
 
-    #List Dumps
+    # List Dumps
     def list_dumps(self) -> List[DumpEntry]:
         result = subprocess.run(
-            ["busctl", "tree", self.BUSNAME],
-            capture_output=True,
-            text=True
+            ["busctl", "tree", self.BUSNAME], capture_output=True, text=True
         )
 
         dumps = []
@@ -28,7 +28,7 @@ class DBusClient:
                         DumpEntry(
                             id=dump_id,
                             type=DumpType.from_path(path),
-                            object_path=path
+                            object_path=path,
                         )
                     )
                 except ValueError:
@@ -36,54 +36,58 @@ class DBusClient:
 
         return dumps
 
-    #Create Dump
+    # Create Dump
     def create_dump(self, dump_type: DumpType, params: Dict = {}) -> str:
         result = subprocess.run(
             [
-                "busctl", "call",
+                "busctl",
+                "call",
                 self.BUSNAME,
                 dump_type.object_path,
                 "xyz.openbmc_project.Dump.Create",
                 "CreateDump",
-                "a{sv}", "0"
+                "a{sv}",
+                "0",
             ],
             capture_output=True,
-            text=True
+            text=True,
         )
 
         print("STDOUT:", result.stdout)
         return result.stdout.strip()
 
-    #Delete Dump
+    # Delete Dump
     def delete_dump(self, object_path: str) -> bool:
         result = subprocess.run(
             [
-                "busctl", "call",
+                "busctl",
+                "call",
                 self.BUSNAME,
                 object_path,
                 "xyz.openbmc_project.Object.Delete",
-                "Delete"
+                "Delete",
             ],
             capture_output=True,
-            text=True
+            text=True,
         )
 
         return result.returncode == 0
 
-    #Get Dump Info
+    # Get Dump Info
     def get_dump_info(self, object_path: str) -> DumpInfo:
 
         def get_property(prop, interface):
             result = subprocess.run(
                 [
-                    "busctl", "get-property",
+                    "busctl",
+                    "get-property",
                     self.BUSNAME,
                     object_path,
                     interface,
-                    prop
+                    prop,
                 ],
                 capture_output=True,
-                text=True
+                text=True,
             )
 
             if result.returncode != 0:
@@ -112,7 +116,7 @@ class DBusClient:
                 dt = datetime.datetime.utcfromtimestamp(ts)
 
                 return dt.strftime("%Y-%m-%d %H:%M:%S")
-            except:
+            except (TypeError, ValueError, OSError, OverflowError):
                 return str(value)
 
         def parse_status(status_raw):
@@ -124,14 +128,30 @@ class DBusClient:
                 return False
             return None
 
+        def as_int(value) -> Optional[int]:
+            return (
+                value
+                if isinstance(value, int) and not isinstance(value, bool)
+                else None
+            )
 
-        size = get_property("Size", "xyz.openbmc_project.Dump.Entry")
-        offloaded = get_property("Offloaded", "xyz.openbmc_project.Dump.Entry")
+        def as_bool(value) -> Optional[bool]:
+            return value if isinstance(value, bool) else None
 
-        started_time_raw = get_property("StartTime", "xyz.openbmc_project.Common.Progress")
-        ended_time_raw = get_property("CompletedTime", "xyz.openbmc_project.Common.Progress")
-        status_raw = get_property("Status", "xyz.openbmc_project.Common.Progress")
+        size = as_int(get_property("Size", "xyz.openbmc_project.Dump.Entry"))
+        offloaded = as_bool(
+            get_property("Offloaded", "xyz.openbmc_project.Dump.Entry")
+        )
 
+        started_time_raw = get_property(
+            "StartTime", "xyz.openbmc_project.Common.Progress"
+        )
+        ended_time_raw = get_property(
+            "CompletedTime", "xyz.openbmc_project.Common.Progress"
+        )
+        status_raw = get_property(
+            "Status", "xyz.openbmc_project.Common.Progress"
+        )
 
         completed = parse_status(status_raw)
         started_time = format_time(started_time_raw)
@@ -147,5 +167,5 @@ class DBusClient:
             completed=completed,
             offloaded=offloaded,
             started_time=started_time,
-            ended_time=ended_time
+            ended_time=ended_time,
         )

--- a/tools/dumptool/services/dump_service.py
+++ b/tools/dumptool/services/dump_service.py
@@ -1,6 +1,7 @@
-from dumptool.clients.dbus_client import DBusClient
-from dumptool.models import DumpType, DumpInfo
 from typing import List
+
+from dumptool.clients.dbus_client import DBusClient
+from dumptool.models import DumpInfo, DumpType
 
 
 class DumpService:


### PR DESCRIPTION
Add getNodeNum() to PHAL targeting interface to retrieve node numbers
for proper dump file naming in multi-node systems.

Changes:
- Add getNodeNum() interface declaration in targeting_iface.hpp
- Implement legacy version returning 0 for single-node systems
- Implement next version using parent HUB_CHIP's FAPI position
- Update SBE dump collector to use actual node number in filenames

Legacy systems continue to use node 0, while next-generation systems
properly identify node numbers from hardware topology. Dump filenames
now correctly reflect the node where the dump originated.

Test results:

Before:
For multi-node systems, only dump file with name plat_dump/<dump-id>.SbeDataClocksOff.node0.sock<id> was getting created and dumps were getting overwritten.
Jul 02 06:07:55 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOff.node0.sock0
Jul 02 06:07:55 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOn.node0.sock0

After this fix:
Dump files created for each node.
Jul 02 06:07:55 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOff.node0.sock0
Jul 02 06:07:55 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOn.node0.sock0

Jul 02 14:28:03 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOff.node3.sock0
Jul 02 14:28:03 huygens openpower-dump-monitor[4610]: plat_dump/20000001.SbeDataClocksOn.node3.sock0

Change-Id: I12363994674151d88a7acdb62b4c7bb0b83d78c4