### PR TITLE
phal: Mark unused parameter in getNodeNum()

### DIFF
--- a/phal/targeting_legacy.cpp
+++ b/phal/targeting_legacy.cpp
@@ -86,7 +86,7 @@ uint32_t chipPos(TargetHandle target)
     return pdbg_target_index(target);
 }
 
-uint32_t getNodeNum(TargetHandle target)
+uint32_t getNodeNum([[maybe_unused]] TargetHandle target)
 {
     return 0;
 }


### PR DESCRIPTION
Add [[maybe_unused]] attribute to target
parameter in getNodeNum() to fix
-Werror=unused-parameter compilation error.

Change-Id: Ibe646f4add2c046c31d8ea080447402931a464da