### PR TITLE
opdump: Add support for pelid

### DIFF
--- a/tools/dumptool/cli.py
+++ b/tools/dumptool/cli.py
@@ -174,6 +174,7 @@ def _print_dump_info(info):
         print(
             f"Error Log ID : 0x{info.error_log_id:08X} ({info.error_log_id})"
         )
+    print(f"PEL ID       : {hex(info.pel_id) if info.pel_id else 'N/A'}")
     if info.failing_unit_id is not None:
         print(f"Failing Unit : {info.failing_unit_id}")
     if info.sbe_dump_trigger_type is not None:

--- a/tools/dumptool/clients/dbus_client.py
+++ b/tools/dumptool/clients/dbus_client.py
@@ -286,7 +286,10 @@ class DBusClient:
         dump_type = DumpType.from_path(object_path)
         subtype = get_subtype(introspection)
 
+        PELID_IFACE = "org.open_power.Logging.PEL.PELID"
+
         error_log_id = None
+        pel_id = None
         failing_unit_id = None
         dump_files_path = None
         sbe_dump_trigger_type = None
@@ -303,6 +306,12 @@ class DBusClient:
                 subtype_interface,
                 optional=True,
             )
+
+        # Read PELID from the new interface (available on all dump types that
+        # carry an error-log association, including system dumps)
+        pel_id = get_property("PELID", PELID_IFACE, optional=True)
+        if pel_id == 0:
+            pel_id = None
         if subtype in ("hardware", "sbe", "memory-buffer-sbe"):
             failing_unit_id = get_property(
                 "FailingUnitId",
@@ -335,6 +344,7 @@ class DBusClient:
             ended_time_us=ended_time_raw,
             operation_status=status_raw,
             error_log_id=error_log_id,
+            pel_id=pel_id,
             failing_unit_id=failing_unit_id,
             dump_files_path=dump_files_path,
             sbe_dump_trigger_type=sbe_dump_trigger_type,

--- a/tools/dumptool/models.py
+++ b/tools/dumptool/models.py
@@ -127,6 +127,7 @@ class DumpInfo:
     ended_time_us: Optional[int] = None
     operation_status: Optional[str] = None
     error_log_id: Optional[int] = None
+    pel_id: Optional[int] = None  # org.open_power.Logging.PEL.PELID
     failing_unit_id: Optional[int] = None
     dump_files_path: Optional[str] = None
     sbe_dump_trigger_type: Optional[str] = None
@@ -185,6 +186,7 @@ class DumpInfo:
             "started_time_us": self.started_time_us,
             "ended_time_us": self.ended_time_us,
             "error_log_id": self.error_log_id,
+            "pel_id": self.pel_id,
             "failing_unit_id": self.failing_unit_id,
             "dump_files_path": self.dump_files_path,
             "sbe_dump_trigger_type": self.sbe_dump_trigger_type,


### PR DESCRIPTION
Test Results:


org.open_power.Logging.PEL.PELID  interface  has PELID property

SBE Dump
```
root@huygens:~# busctl introspect xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system/entry/30000001
NAME                                    TYPE      SIGNATURE RESULT/VALUE                             FLAGS
com.ibm.Dump.Entry.SBE                  interface -         -                                        -
.DumpFilesPath                          property  s         ""                                       emits-change writable
.ErrorLogId                             property  u         3735928559                               emits-change writable
.FailingUnitId                          property  u         1                                        emits-change writable
.SBEDumpTriggerType                     property  s         "com.ibm.Dump.Create.SBEDumpTriggerType… emits-change writable
org.freedesktop.DBus.Introspectable     interface -         -                                        -
.Introspect                             method    -         s                                        -
org.freedesktop.DBus.Peer               interface -         -                                        -
.GetMachineId                           method    -         s                                        -
.Ping                                   method    -         -                                        -
org.freedesktop.DBus.Properties         interface -         -                                        -
.Get                                    method    ss        v                                        -
.GetAll                                 method    s         a{sv}                                    -
.Set                                    method    ssv       -                                        -
.PropertiesChanged                      signal    sa{sv}as  -                                        -
org.open_power.Logging.PEL.PELID        interface -         -                                        -
.PELID                                  property  u         3735928559                               emits-change
```

MSBE Dump
```
root@huygens:~# busctl introspect xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system/entry/40000002
NAME                                    TYPE      SIGNATURE RESULT/VALUE                             FLAGS
com.ibm.Dump.Entry.SBE                  interface -         -                                        -
.DumpFilesPath                          property  s         ""                                       emits-change writable
.ErrorLogId                             property  u         3735928559                               emits-change writable
.FailingUnitId                          property  u         2                                        emits-change writable
.SBEDumpTriggerType                     property  s         "com.ibm.Dump.Create.SBEDumpTriggerType… emits-change writable
org.freedesktop.DBus.Introspectable     interface -         -                                        -
.Introspect                             method    -         s                                        -
org.freedesktop.DBus.Peer               interface -         -                                        -
.GetMachineId                           method    -         s                                        -
.Ping                                   method    -         -                                        -
org.freedesktop.DBus.Properties         interface -         -                                        -
.Get                                    method    ss        v                                        -
.GetAll                                 method    s         a{sv}                                    -
.Set                                    method    ssv       -                                        -
.PropertiesChanged                      signal    sa{sv}as  -                                        -
org.open_power.Logging.PEL.PELID        interface -         -                                        -
.PELID                                  property  u         3735928559                               emits-change
```

SYSTEM Dump
```
root@huygens:/var/lib/phosphor-debug-collector/opdump/A0000002# busctl introspect xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system/entry/A0000002
NAME                                    TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable     interface -         -                                        -
.Introspect                             method    -         s                                        -
org.freedesktop.DBus.Peer               interface -         -                                        -
.GetMachineId                           method    -         s                                        -
.Ping                                   method    -         -                                        -
org.freedesktop.DBus.Properties         interface -         -                                        -
.Get                                    method    ss        v                                        -
.GetAll                                 method    s         a{sv}                                    -
.Set                                    method    ssv       -                                        -
.PropertiesChanged                      signal    sa{sv}as  -                                        -
org.open_power.Logging.PEL.PELID        interface -         -                                        -
.PELID                                  property  u         0                                        emits-change
```