### PR TITLE
dumptool: add system dump support

### DIFF
--- a/tools/dumptool/models.py
+++ b/tools/dumptool/models.py
@@ -50,6 +50,9 @@ class DumpCreateSpec:
 
 DUMP_CREATE_SPECS: Dict[DumpType, DumpCreateSpec] = {
     DumpType.BMC: DumpCreateSpec(dbus_type=None),
+    DumpType.SYSTEM: DumpCreateSpec(
+        dbus_type="System",
+    ),
     DumpType.HOSTBOOT: DumpCreateSpec(
         dbus_type="Hostboot",
         requires_error_log_id=True,


### PR DESCRIPTION
Added system dump support 

Test Results- BMC Machine

```
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli create --type system
✔ Dump created successfully
Dump ID : A000000C
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli get-info A000000C
ID           : A000000C
Type         : system
Size (KB)    : -
Start Time   : 2026-08-18 08:16:48
End Time     : N/A
Status       : In Progress
Offloaded    : False
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       -            2026-08-18 08:16:48  -                    In Progress
root@p11bmc:/tmp/dumptool# python3 -m dumptool.cli list --type system
ID         Type         Size(KB)     Start Time           End Time             Status
A000000C   system       2857251 KB   2026-08-18 08:16:48  2026-08-18 08:19:43  Completed
```